### PR TITLE
feat: Three.js 기반 3D 지도 뷰 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "@types/three": "^0.183.1",
     "lucide-react": "^0.577.0",
     "next": "16.2.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "three": "^0.183.2",
     "uuid": "^13.0.0",
     "zustand": "^5.0.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/three':
+        specifier: ^0.183.1
+        version: 0.183.1
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -20,6 +23,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      three:
+        specifier: ^0.183.2
+        version: 0.183.2
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -196,6 +202,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -906,6 +915,9 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -944,9 +956,18 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.183.1':
+    resolution: {integrity: sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==}
+
   '@types/uuid@11.0.0':
     resolution: {integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==}
     deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
@@ -1144,6 +1165,9 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@webgpu/types@0.1.69':
+    resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1633,6 +1657,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -2089,6 +2116,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  meshoptimizer@1.0.1:
+    resolution: {integrity: sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -2507,6 +2537,9 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  three@0.183.2:
+    resolution: {integrity: sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2928,6 +2961,8 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -3420,6 +3455,8 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -3466,9 +3503,23 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.183.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      '@webgpu/types': 0.1.69
+      fflate: 0.8.2
+      meshoptimizer: 1.0.1
+
   '@types/uuid@11.0.0':
     dependencies:
       uuid: 13.0.0
+
+  '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3671,6 +3722,8 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@webgpu/types@0.1.69': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -4331,6 +4384,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.8.2: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -4780,6 +4835,8 @@ snapshots:
   math-intrinsics@1.1.0: {}
 
   merge2@1.4.1: {}
+
+  meshoptimizer@1.0.1: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -5284,6 +5341,8 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tapable@2.3.0: {}
+
+  three@0.183.2: {}
 
   tinybench@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 ignoredBuiltDependencies:
+  - esbuild
   - sharp
   - unrs-resolver

--- a/src/components/map/MapPanel.tsx
+++ b/src/components/map/MapPanel.tsx
@@ -1,26 +1,100 @@
 'use client';
 
+import { useState, useCallback } from 'react';
 import dynamic from 'next/dynamic';
-import { MapPin } from 'lucide-react';
+import { MapPin, Box, Map } from 'lucide-react';
 import { useMapStore } from '@/stores/mapStore';
 import PlaceCard from '@/components/chat/PlaceCard';
 import EmptyState from '@/components/ui/EmptyState';
 
 const KakaoMap = dynamic(() => import('./KakaoMap'), { ssr: false });
+const ThreeMap = dynamic(() => import('./ThreeMap'), { ssr: false });
 
 export default function MapPanel() {
   const markers = useMapStore((s) => s.markers);
   const selectedPlace = useMapStore((s) => s.selectedPlace);
   const selectPlace = useMapStore((s) => s.selectPlace);
+  const mapCenter = useMapStore((s) => s.mapCenter);
+
+  const [is3D, setIs3D] = useState(false);
+  const [loading3D, setLoading3D] = useState(false);
+  const [buildingCount, setBuildingCount] = useState(0);
+  const [error3D, setError3D] = useState<string | null>(null);
+
+  const handleLoadingChange = useCallback((v: boolean) => setLoading3D(v), []);
+  const handleBuildingCount = useCallback((n: number) => setBuildingCount(n), []);
+  const handleError = useCallback((msg: string) => {
+    setError3D(msg);
+    setTimeout(() => setError3D(null), 4000);
+  }, []);
 
   return (
     <div className="h-full flex flex-col bg-bg-base">
       <div className="flex-1 relative m-3 overflow-hidden rounded-2xl border border-border shadow-sm">
-        {markers.length > 0 ? (
-          <KakaoMap markers={markers} selectedPlace={selectedPlace} onSelectPlace={selectPlace} />
+        {markers.length > 0 || is3D ? (
+          <>
+            {is3D ? (
+              <ThreeMap
+                markers={markers}
+                selectedPlace={selectedPlace}
+                center={mapCenter}
+                zoom={16}
+                onLoadingChange={handleLoadingChange}
+                onBuildingCount={handleBuildingCount}
+                onError={handleError}
+              />
+            ) : (
+              <KakaoMap
+                markers={markers}
+                selectedPlace={selectedPlace}
+                onSelectPlace={selectPlace}
+              />
+            )}
+
+            {/* 2D/3D Toggle */}
+            <button
+              onClick={() => { setIs3D(!is3D); setError3D(null); }}
+              className="absolute top-3 right-3 z-10 flex items-center gap-1.5 px-3 py-2 rounded-xl text-[13px] font-semibold shadow-md transition-all duration-200 cursor-pointer"
+              style={{
+                background: is3D ? '#DC2626' : '#2563EB',
+                color: 'white',
+              }}
+            >
+              {is3D ? <Map size={14} /> : <Box size={14} />}
+              {is3D ? '2D 보기' : '3D 보기'}
+            </button>
+
+            {/* 3D Loading */}
+            {loading3D && (
+              <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+                <div className="flex items-center gap-3 bg-white/90 px-5 py-3 rounded-xl shadow-lg">
+                  <div className="w-5 h-5 border-2 border-brand/30 border-t-brand rounded-full animate-spin" />
+                  <span className="text-[13px] font-medium text-text-primary">건물 데이터 로딩 중...</span>
+                </div>
+              </div>
+            )}
+
+            {/* Building count */}
+            {is3D && !loading3D && buildingCount > 0 && (
+              <div className="absolute bottom-3 left-3 z-10 px-3 py-1.5 rounded-lg bg-black/60 text-white text-[11px] font-medium backdrop-blur-sm">
+                {buildingCount.toLocaleString()}개 건물
+              </div>
+            )}
+
+            {/* Error toast */}
+            {error3D && (
+              <div className="absolute top-14 right-3 z-10 px-3 py-2 rounded-lg bg-red-600 text-white text-[12px] font-medium shadow-lg animate-fade-up">
+                {error3D}
+              </div>
+            )}
+          </>
         ) : (
           <div className="h-full bg-bg-subtle">
-            <EmptyState icon={MapPin} title="지도 탐색" description="에이전트에게 장소를 추천받으면 여기에 표시돼요" />
+            <EmptyState
+              icon={MapPin}
+              title="지도 탐색"
+              description="에이전트에게 장소를 추천받으면 여기에 표시돼요"
+            />
           </div>
         )}
       </div>

--- a/src/components/map/ThreeMap.tsx
+++ b/src/components/map/ThreeMap.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+import { MapScene3D } from '@/lib/three-scene';
+import { fetchBuildings } from '@/lib/overpass';
+import type { Place } from '@/types';
+
+interface ThreeMapProps {
+  markers: Place[];
+  selectedPlace: Place | null;
+  center: { lat: number; lng: number };
+  zoom: number;
+  onLoadingChange: (loading: boolean) => void;
+  onBuildingCount: (count: number) => void;
+  onError: (msg: string) => void;
+}
+
+export default function ThreeMap({
+  markers,
+  selectedPlace,
+  center,
+  zoom,
+  onLoadingChange,
+  onBuildingCount,
+  onError,
+}: ThreeMapProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const sceneRef = useRef<MapScene3D | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const loadedCenterRef = useRef<string>('');
+
+  // Initialize scene
+  useEffect(() => {
+    if (!canvasRef.current) return;
+
+    const scene = new MapScene3D(canvasRef.current);
+    sceneRef.current = scene;
+    scene.start();
+
+    return () => {
+      scene.dispose();
+      sceneRef.current = null;
+    };
+  }, []);
+
+  // Resize observer
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const ro = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      if (width > 0 && height > 0) {
+        sceneRef.current?.resize(width, height);
+      }
+    });
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, []);
+
+  // Load buildings + tiles when center changes
+  const loadArea = useCallback(async () => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+
+    const key = `${center.lat.toFixed(4)},${center.lng.toFixed(4)},${zoom}`;
+    if (loadedCenterRef.current === key) return;
+    loadedCenterRef.current = key;
+
+    onLoadingChange(true);
+    try {
+      // Calculate bounds from center + zoom
+      const latSpan = 0.01 * Math.pow(2, 16 - zoom);
+      const lonSpan = latSpan * 1.3;
+      const bounds = {
+        south: center.lat - latSpan / 2,
+        north: center.lat + latSpan / 2,
+        west: center.lng - lonSpan / 2,
+        east: center.lng + lonSpan / 2,
+      };
+
+      const buildings = await fetchBuildings(bounds.south, bounds.west, bounds.north, bounds.east);
+      onBuildingCount(buildings.length);
+
+      scene.loadBuildings(buildings, { lat: center.lat, lon: center.lng });
+      await scene.loadGround(bounds, zoom);
+      scene.resetCamera();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : '3D 로딩 실패');
+      loadedCenterRef.current = '';
+    } finally {
+      onLoadingChange(false);
+    }
+  }, [center, zoom, onLoadingChange, onBuildingCount, onError]);
+
+  useEffect(() => {
+    loadArea();
+  }, [loadArea]);
+
+  // Update place markers
+  useEffect(() => {
+    sceneRef.current?.setPlaceMarkers(markers, selectedPlace?.id);
+  }, [markers, selectedPlace]);
+
+  return (
+    <div ref={containerRef} className="w-full h-full relative" style={{ minHeight: 300 }}>
+      <canvas ref={canvasRef} className="w-full h-full block" />
+    </div>
+  );
+}

--- a/src/lib/overpass.ts
+++ b/src/lib/overpass.ts
@@ -1,0 +1,157 @@
+/**
+ * Overpass API를 통해 OpenStreetMap 건물 데이터를 가져옴
+ */
+
+const OVERPASS_URLS = [
+  'https://overpass-api.de/api/interpreter',
+  'https://overpass.kumi.systems/api/interpreter',
+];
+
+const MAX_BBOX_DEGREES = 0.015;
+
+export interface BuildingData {
+  id: string;
+  coords: [number, number][]; // [lat, lon]
+  height: number;
+  tags: Record<string, string>;
+}
+
+export async function fetchBuildings(
+  south: number,
+  west: number,
+  north: number,
+  east: number,
+): Promise<BuildingData[]> {
+  const latSpan = north - south;
+  const lonSpan = east - west;
+
+  if (latSpan > MAX_BBOX_DEGREES || lonSpan > MAX_BBOX_DEGREES) {
+    const centerLat = (south + north) / 2;
+    const centerLon = (west + east) / 2;
+    const halfLat = Math.min(latSpan, MAX_BBOX_DEGREES) / 2;
+    const halfLon = Math.min(lonSpan, MAX_BBOX_DEGREES) / 2;
+    south = centerLat - halfLat;
+    north = centerLat + halfLat;
+    west = centerLon - halfLon;
+    east = centerLon + halfLon;
+  }
+
+  const query = `
+    [out:json][timeout:90];
+    (
+      way["building"](${south},${west},${north},${east});
+      relation["building"](${south},${west},${north},${east});
+    );
+    out body;
+    >;
+    out skel qt;
+  `;
+
+  for (const url of OVERPASS_URLS) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: `data=${encodeURIComponent(query)}`,
+        signal: AbortSignal.timeout(60000),
+      });
+
+      if (!response.ok) continue;
+
+      const data = await response.json();
+      return parseBuildings(data);
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error('모든 Overpass 서버가 응답하지 않습니다.');
+}
+
+interface OverpassElement {
+  type: 'node' | 'way' | 'relation';
+  id: number;
+  lat?: number;
+  lon?: number;
+  nodes?: number[];
+  members?: { type: string; ref: number; role: string }[];
+  tags?: Record<string, string>;
+}
+
+function parseBuildings(data: { elements: OverpassElement[] }): BuildingData[] {
+  const nodes = new Map<number, { lat: number; lon: number }>();
+  const ways = new Map<number, OverpassElement>();
+  const buildings: BuildingData[] = [];
+
+  for (const el of data.elements) {
+    if (el.type === 'node' && el.lat !== undefined && el.lon !== undefined) {
+      nodes.set(el.id, { lat: el.lat, lon: el.lon });
+    }
+    if (el.type === 'way') {
+      ways.set(el.id, el);
+    }
+  }
+
+  function wayToCoords(wayEl: OverpassElement): [number, number][] | null {
+    if (!wayEl.nodes) return null;
+    const coords: [number, number][] = [];
+    for (const nodeId of wayEl.nodes) {
+      const node = nodes.get(nodeId);
+      if (!node) return null;
+      coords.push([node.lat, node.lon]);
+    }
+    return coords.length >= 3 ? coords : null;
+  }
+
+  for (const el of data.elements) {
+    if (el.type !== 'way' || !el.tags?.building) continue;
+    const coords = wayToCoords(el);
+    if (!coords) continue;
+    buildings.push({
+      id: String(el.id),
+      coords,
+      height: estimateHeight(el.tags),
+      tags: el.tags,
+    });
+  }
+
+  for (const el of data.elements) {
+    if (el.type !== 'relation' || !el.tags?.building || !el.members) continue;
+    const height = estimateHeight(el.tags);
+    for (const member of el.members) {
+      if (member.type !== 'way' || member.role !== 'outer') continue;
+      const wayEl = ways.get(member.ref);
+      if (!wayEl) continue;
+      const coords = wayToCoords(wayEl);
+      if (!coords) continue;
+      buildings.push({
+        id: `${el.id}-${member.ref}`,
+        coords,
+        height,
+        tags: el.tags,
+      });
+    }
+  }
+
+  return buildings;
+}
+
+function estimateHeight(tags: Record<string, string>): number {
+  if (tags.height) {
+    const h = parseFloat(tags.height);
+    if (!isNaN(h)) return h;
+  }
+  if (tags['building:levels']) {
+    const levels = parseInt(tags['building:levels'], 10);
+    if (!isNaN(levels)) return levels * 3;
+  }
+
+  const typeHeights: Record<string, number> = {
+    apartments: 30, commercial: 15, office: 25, retail: 6,
+    industrial: 10, warehouse: 8, church: 15, cathedral: 30,
+    hospital: 20, school: 12, university: 15, hotel: 25, skyscraper: 100,
+  };
+
+  if (typeHeights[tags.building]) return typeHeights[tags.building];
+  return 3 + Math.random() * 9;
+}

--- a/src/lib/three-scene.ts
+++ b/src/lib/three-scene.ts
@@ -1,0 +1,424 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import type { BuildingData } from './overpass';
+import type { Place } from '@/types';
+
+// ── Tile helpers ──
+
+const TILE_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+function lonLatToTile(lon: number, lat: number, zoom: number) {
+  const n = Math.pow(2, zoom);
+  const x = Math.floor(((lon + 180) / 360) * n);
+  const latRad = (lat * Math.PI) / 180;
+  const y = Math.floor(((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n);
+  return { x, y };
+}
+
+function tileToLonLat(x: number, y: number, zoom: number) {
+  const n = Math.pow(2, zoom);
+  const lon = (x / n) * 360 - 180;
+  const latRad = Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / n)));
+  const lat = (latRad * 180) / Math.PI;
+  return { lon, lat };
+}
+
+// ── Scene ──
+
+export interface Bounds {
+  south: number;
+  west: number;
+  north: number;
+  east: number;
+}
+
+export class MapScene3D {
+  private canvas: HTMLCanvasElement;
+  private renderer: THREE.WebGLRenderer;
+  private scene: THREE.Scene;
+  private camera: THREE.PerspectiveCamera;
+  private controls: OrbitControls;
+  private buildings: THREE.Mesh[] = [];
+  private tileGroup: THREE.Group | null = null;
+  private placeMarkers: THREE.Group[] = [];
+  private gpsMarker: THREE.Group | null = null;
+  private running = false;
+
+  private centerMercX = 0;
+  private centerMercY = 0;
+  private center = { lat: 37.5665, lon: 126.978 };
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+
+    // Renderer
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    this.renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.shadowMap.enabled = true;
+    this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    this.renderer.toneMappingExposure = 1.1;
+
+    // Scene
+    this.scene = new THREE.Scene();
+    this.scene.background = new THREE.Color(0xb8d4e8);
+    this.scene.fog = new THREE.Fog(0xb8d4e8, 3000, 8000);
+
+    // Camera
+    this.camera = new THREE.PerspectiveCamera(50, canvas.clientWidth / canvas.clientHeight, 1, 50000);
+    this.camera.position.set(0, 600, 800);
+    this.camera.lookAt(0, 0, 0);
+
+    // Controls
+    this.controls = new OrbitControls(this.camera, canvas);
+    this.controls.enableDamping = true;
+    this.controls.dampingFactor = 0.08;
+    this.controls.maxPolarAngle = Math.PI / 2.05;
+    this.controls.minPolarAngle = 0.1;
+    this.controls.minDistance = 50;
+    this.controls.maxDistance = 4000;
+
+    // Lights
+    this.scene.add(new THREE.AmbientLight(0xffffff, 0.8));
+
+    const sun = new THREE.DirectionalLight(0xfff5e6, 1.2);
+    sun.position.set(400, 800, 300);
+    sun.castShadow = true;
+    sun.shadow.mapSize.set(4096, 4096);
+    const d = 2000;
+    sun.shadow.camera.left = -d;
+    sun.shadow.camera.right = d;
+    sun.shadow.camera.top = d;
+    sun.shadow.camera.bottom = -d;
+    this.scene.add(sun);
+
+    this.scene.add(new THREE.DirectionalLight(0x8ecae6, 0.3).translateX(-300).translateY(200).translateZ(-200));
+    this.scene.add(new THREE.HemisphereLight(0xb8d4e8, 0x444444, 0.4));
+
+    this.animate = this.animate.bind(this);
+  }
+
+  // ── Mercator ──
+
+  private latLonToMercator(lat: number, lon: number) {
+    const R = 6378137;
+    const x = R * (lon * Math.PI) / 180;
+    const latRad = (lat * Math.PI) / 180;
+    const y = R * Math.log(Math.tan(Math.PI / 4 + latRad / 2));
+    return { x, y };
+  }
+
+  private latLonToLocal(lat: number, lon: number) {
+    const merc = this.latLonToMercator(lat, lon);
+    return {
+      x: merc.x - this.centerMercX,
+      z: -(merc.y - this.centerMercY),
+    };
+  }
+
+  private setCenter(lat: number, lon: number) {
+    this.center = { lat, lon };
+    const merc = this.latLonToMercator(lat, lon);
+    this.centerMercX = merc.x;
+    this.centerMercY = merc.y;
+  }
+
+  // ── Ground tiles ──
+
+  async loadGround(bounds: Bounds, zoom: number) {
+    if (this.tileGroup) {
+      this.tileGroup.traverse((child) => {
+        if ((child as THREE.Mesh).isMesh) {
+          (child as THREE.Mesh).geometry.dispose();
+          const mat = (child as THREE.Mesh).material as THREE.MeshBasicMaterial;
+          mat.map?.dispose();
+          mat.dispose();
+        }
+      });
+      this.scene.remove(this.tileGroup);
+    }
+
+    const group = new THREE.Group();
+    const tlTile = lonLatToTile(bounds.west, bounds.north, zoom);
+    const brTile = lonLatToTile(bounds.east, bounds.south, zoom);
+
+    const loader = new THREE.TextureLoader();
+    loader.crossOrigin = 'anonymous';
+
+    const promises: Promise<void>[] = [];
+
+    for (let tx = tlTile.x - 1; tx <= brTile.x + 1; tx++) {
+      for (let ty = tlTile.y - 1; ty <= brTile.y + 1; ty++) {
+        const url = TILE_URL.replace('{z}', String(zoom)).replace('{x}', String(tx)).replace('{y}', String(ty));
+        const nw = tileToLonLat(tx, ty, zoom);
+        const se = tileToLonLat(tx + 1, ty + 1, zoom);
+        const tl = this.latLonToLocal(nw.lat, nw.lon);
+        const br = this.latLonToLocal(se.lat, se.lon);
+
+        const p = new Promise<void>((resolve) => {
+          loader.load(url, (texture) => {
+            texture.minFilter = THREE.LinearFilter;
+            texture.magFilter = THREE.LinearFilter;
+            texture.colorSpace = THREE.SRGBColorSpace;
+
+            const geo = new THREE.BufferGeometry();
+            geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array([
+              tl.x, 0, tl.z, br.x, 0, tl.z, tl.x, 0, br.z, br.x, 0, br.z,
+            ]), 3));
+            geo.setAttribute('uv', new THREE.BufferAttribute(new Float32Array([
+              0, 1, 1, 1, 0, 0, 1, 0,
+            ]), 2));
+            geo.setIndex([0, 2, 1, 1, 2, 3]);
+            geo.computeVertexNormals();
+
+            const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide });
+            group.add(new THREE.Mesh(geo, mat));
+            resolve();
+          }, undefined, () => resolve());
+        });
+        promises.push(p);
+      }
+    }
+
+    await Promise.all(promises);
+    group.position.y = -0.1;
+    this.scene.add(group);
+    this.tileGroup = group;
+  }
+
+  // ── Buildings ──
+
+  loadBuildings(buildings: BuildingData[], center: { lat: number; lon: number }) {
+    this.clearBuildings();
+    this.setCenter(center.lat, center.lon);
+
+    const getColor = (h: number) => {
+      if (h > 60) return 0x1a3a5c;
+      if (h > 30) return 0x2d5a8e;
+      if (h > 15) return 0x4a8cc7;
+      if (h > 8) return 0x6baed6;
+      return 0x9ecae1;
+    };
+
+    for (const b of buildings) {
+      try {
+        const shape = new THREE.Shape();
+        const pts = b.coords.map(([lat, lon]) => this.latLonToLocal(lat, lon));
+        shape.moveTo(pts[0].x, -pts[0].z);
+        for (let i = 1; i < pts.length; i++) shape.lineTo(pts[i].x, -pts[i].z);
+        shape.closePath();
+
+        const geo = new THREE.ExtrudeGeometry(shape, { depth: b.height, bevelEnabled: false });
+        geo.rotateX(-Math.PI / 2);
+
+        const mesh = new THREE.Mesh(geo, new THREE.MeshPhongMaterial({
+          color: getColor(b.height),
+          transparent: true,
+          opacity: 0.92,
+          shininess: 30,
+        }));
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        mesh.scale.y = 0.01;
+        mesh.userData.targetScaleY = 1;
+
+        // Edge lines
+        const edges = new THREE.LineSegments(
+          new THREE.EdgesGeometry(geo, 30),
+          new THREE.LineBasicMaterial({ color: b.height > 30 ? 0x0f2744 : 0x2a4a6b, transparent: true, opacity: 0.3 }),
+        );
+        mesh.add(edges);
+
+        this.scene.add(mesh);
+        this.buildings.push(mesh);
+      } catch { /* skip invalid */ }
+    }
+
+    this.animateBuildings();
+  }
+
+  private animateBuildings() {
+    const duration = 1200;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const progress = Math.min((now - start) / duration, 1);
+      const ease = 1 + 2.7 * Math.pow(progress - 1, 3) + 1.7 * Math.pow(progress - 1, 2);
+      for (const m of this.buildings) m.scale.y = ease * m.userData.targetScaleY;
+      if (progress < 1) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  }
+
+  private clearBuildings() {
+    for (const m of this.buildings) {
+      m.traverse((c) => {
+        if ((c as THREE.Mesh).geometry) (c as THREE.Mesh).geometry.dispose();
+        const mat = (c as THREE.Mesh).material;
+        if (mat) {
+          if (Array.isArray(mat)) mat.forEach((mm) => mm.dispose());
+          else (mat as THREE.Material).dispose();
+        }
+      });
+      this.scene.remove(m);
+    }
+    this.buildings = [];
+  }
+
+  // ── Place markers (pins in 3D) ──
+
+  setPlaceMarkers(places: Place[], selectedId?: string) {
+    // Clear old
+    for (const g of this.placeMarkers) {
+      g.traverse((c) => {
+        if ((c as THREE.Mesh).geometry) (c as THREE.Mesh).geometry.dispose();
+        if ((c as THREE.Mesh).material) ((c as THREE.Mesh).material as THREE.Material).dispose();
+      });
+      this.scene.remove(g);
+    }
+    this.placeMarkers = [];
+
+    const categoryColors: Record<string, number> = {
+      tourism: 0x2563eb, shopping: 0xea580c, culture: 0x7c3aed, food: 0xdc2626,
+    };
+
+    for (const place of places) {
+      const pos = this.latLonToLocal(place.lat, place.lng);
+      const group = new THREE.Group();
+      const isSelected = place.id === selectedId;
+
+      // Pin sphere
+      const radius = isSelected ? 12 : 8;
+      const sphere = new THREE.Mesh(
+        new THREE.SphereGeometry(radius, 16, 16),
+        new THREE.MeshPhongMaterial({
+          color: categoryColors[place.category] ?? 0x2563eb,
+          emissive: categoryColors[place.category] ?? 0x2563eb,
+          emissiveIntensity: isSelected ? 0.5 : 0.2,
+        }),
+      );
+      sphere.position.y = 50;
+      group.add(sphere);
+
+      // Pole
+      const pole = new THREE.Mesh(
+        new THREE.CylinderGeometry(1.5, 1.5, 50, 8),
+        new THREE.MeshBasicMaterial({ color: 0x666666, transparent: true, opacity: 0.5 }),
+      );
+      pole.position.y = 25;
+      group.add(pole);
+
+      // Ground ring
+      const ring = new THREE.Mesh(
+        new THREE.RingGeometry(6, 10, 32),
+        new THREE.MeshBasicMaterial({
+          color: categoryColors[place.category] ?? 0x2563eb,
+          transparent: true,
+          opacity: 0.4,
+          side: THREE.DoubleSide,
+        }),
+      );
+      ring.rotation.x = -Math.PI / 2;
+      ring.position.y = 1;
+      group.add(ring);
+
+      group.position.set(pos.x, 0, pos.z);
+      this.scene.add(group);
+      this.placeMarkers.push(group);
+    }
+  }
+
+  // ── GPS marker ──
+
+  updateGPSMarker(lat: number, lon: number) {
+    const pos = this.latLonToLocal(lat, lon);
+
+    if (!this.gpsMarker) {
+      const group = new THREE.Group();
+
+      const sphere = new THREE.Mesh(
+        new THREE.SphereGeometry(8, 16, 16),
+        new THREE.MeshPhongMaterial({ color: 0x4285f4, emissive: 0x2255cc, emissiveIntensity: 0.5 }),
+      );
+      sphere.position.y = 20;
+      group.add(sphere);
+
+      const ring = new THREE.Mesh(
+        new THREE.RingGeometry(12, 18, 32),
+        new THREE.MeshBasicMaterial({ color: 0x4285f4, transparent: true, opacity: 0.4, side: THREE.DoubleSide }),
+      );
+      ring.rotation.x = -Math.PI / 2;
+      ring.position.y = 1;
+      group.add(ring);
+
+      const beam = new THREE.Mesh(
+        new THREE.CylinderGeometry(2, 2, 40, 8),
+        new THREE.MeshBasicMaterial({ color: 0x4285f4, transparent: true, opacity: 0.3 }),
+      );
+      beam.position.y = 20;
+      group.add(beam);
+
+      this.gpsMarker = group;
+      this.scene.add(this.gpsMarker);
+    }
+
+    this.gpsMarker.position.set(pos.x, 0, pos.z);
+  }
+
+  removeGPSMarker() {
+    if (this.gpsMarker) {
+      this.gpsMarker.traverse((c) => {
+        if ((c as THREE.Mesh).geometry) (c as THREE.Mesh).geometry.dispose();
+        if ((c as THREE.Mesh).material) ((c as THREE.Mesh).material as THREE.Material).dispose();
+      });
+      this.scene.remove(this.gpsMarker);
+      this.gpsMarker = null;
+    }
+  }
+
+  // ── Lifecycle ──
+
+  resetCamera() {
+    this.camera.position.set(0, 600, 800);
+    this.controls.target.set(0, 0, 0);
+    this.controls.update();
+  }
+
+  start() {
+    this.running = true;
+    this.animate();
+  }
+
+  stop() {
+    this.running = false;
+  }
+
+  private animate() {
+    if (!this.running) return;
+    requestAnimationFrame(this.animate);
+    this.controls.update();
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  resize(w: number, h: number) {
+    this.camera.aspect = w / h;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(w, h);
+  }
+
+  dispose() {
+    this.stop();
+    this.clearBuildings();
+    this.removeGPSMarker();
+    if (this.tileGroup) {
+      this.tileGroup.traverse((c) => {
+        if ((c as THREE.Mesh).isMesh) {
+          (c as THREE.Mesh).geometry.dispose();
+          ((c as THREE.Mesh).material as THREE.Material).dispose();
+        }
+      });
+    }
+    this.controls.dispose();
+    this.renderer.dispose();
+  }
+}


### PR DESCRIPTION
## 작업 내용
- Three.js로 3D 지도 뷰 구현
- OpenStreetMap 타일 + Overpass API 빌딩 데이터 활용
- 3D 빌딩 익스트루드, 카테고리별 마커, GPS 위치 표시
- `MapScene3D` 클래스로 렌더링 로직 캡슐화

## 변경 파일
- `src/components/map/ThreeMap.tsx` — Three.js 캔버스 컴포넌트
- `src/lib/three-scene.ts` — Scene/렌더링 로직
- `src/lib/overpass.ts` — Overpass API 빌딩 데이터 fetcher
- `src/components/map/MapPanel.tsx` — 2D/3D 뷰 토글

## 체크리스트
- [x] 빌딩 데이터 동적 import로 lazy 로딩
- [x] dispose 정리 (Three.js 메모리 누수 방지)
- [x] 모바일 반응형