### PR TITLE
feat: AgentMark — 88 올림픽 엠블럼 모티브 에이전트 마크

### DIFF
--- a/src/components/agent/AgentMark.tsx
+++ b/src/components/agent/AgentMark.tsx
@@ -1,0 +1,41 @@
+import type { AgentType } from '@/types';
+
+const AGENT_PALETTES: Record<AgentType, { primary: string; secondary: string; accent: string }> = {
+  claude: { primary: '#1F3A8B', secondary: '#DC2127', accent: '#F4A12C' },
+  gpt: { primary: '#00853E', secondary: '#5BA86A', accent: '#F4A12C' },
+  gemini: { primary: '#F4A12C', secondary: '#FFC72C', accent: '#DC2127' },
+};
+
+interface AgentMarkProps {
+  agent: AgentType;
+  size?: number;
+  className?: string;
+  spinDuration?: number;
+}
+
+export default function AgentMark({ agent, size = 28, className = '', spinDuration = 8 }: AgentMarkProps) {
+  const p = AGENT_PALETTES[agent];
+
+  return (
+    <div className={`shrink-0 ${className}`} style={{ width: size, height: size }} aria-label={`${agent} mark`}>
+      <svg
+        viewBox="0 0 24 24"
+        width="100%"
+        height="100%"
+        preserveAspectRatio="xMidYMid meet"
+        style={{
+          animation: `orbSpin ${spinDuration}s linear infinite`,
+          willChange: 'transform',
+          transformOrigin: 'center',
+        }}
+      >
+        {/* Tri-segment pinwheel — 88 emblem swirl */}
+        <path d="M 12 12 L 12 0 A 12 12 0 0 1 22.392 18 Z" fill={p.primary} />
+        <path d="M 12 12 L 22.392 18 A 12 12 0 0 1 1.608 18 Z" fill={p.secondary} />
+        <path d="M 12 12 L 1.608 18 A 12 12 0 0 1 12 0 Z" fill={p.accent} />
+        {/* Inner white dot — emblem center */}
+        <circle cx="12" cy="12" r="2.4" fill="#FFFFFF" />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용
- **AgentMark** — 에이전트별 시각 정체성 마크 컴포넌트 신규
- 88 서울올림픽 엠블럼의 삼색 swirl을 차용한 **3분할 풍차** SVG
- \`orbSpin\` 회전 애니메이션 (8s linear infinite, prop으로 조절 가능)
- 에이전트별 트라이컬러 팔레트:
  - **Claude**: 네이비 + 빨강 + 주황 (88 엠블럼 정통 삼색)
  - **GPT**: 그린 + 세이지 + 주황
  - **Gemini**: 주황 + 노랑 + 빨강

## 사용처
PR3의 \`MessageBubble\`, \`StreamingBubble\`, \`TypingIndicator\`에서 import.

## 변경 전 → 후
- 옛 디자인: 3% 알파 보라 틴트 + "C" 한 글자 (정체성 약함)
- 새 디자인: 단색 풍차 + 에이전트별 컬러 + 회전 애니메이션

🤖 Generated with [Claude Code](https://claude.com/claude-code)