### PR TITLE
feat: API 통합 후속 UI — 사이드바 사용자/설정/로그아웃 + 토스트 + Calendar 콜백

### DIFF
--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -1,6 +1,8 @@
 import { memo } from 'react';
-import { X, Plus, MessageCircle, Trash2 } from 'lucide-react';
+import { X, Plus, MessageCircle, Trash2, Settings, LogOut, User } from 'lucide-react';
+import { Link, useNavigate } from 'react-router-dom';
 import { useChatStore, type ChatSession } from '@/stores/chatStore';
+import { useAuthStore } from '@/stores/authStore';
 import { AGENT_COLORS, cn } from '@/lib/utils';
 
 interface ChatSidebarProps {
@@ -24,11 +26,14 @@ function formatDate(dateStr: string): string {
 }
 
 export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) {
+  const navigate = useNavigate();
   const sessions = useChatStore((s) => s.sessions);
   const sessionId = useChatStore((s) => s.sessionId);
   const newChat = useChatStore((s) => s.newChat);
   const loadSession = useChatStore((s) => s.loadSession);
   const deleteSession = useChatStore((s) => s.deleteSession);
+  const user = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
 
   const handleNewChat = () => {
     newChat();
@@ -39,6 +44,15 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
     loadSession(id);
     onClose();
   };
+
+  const handleLogout = () => {
+    logout();
+    onClose();
+    navigate('/login', { replace: true });
+  };
+
+  const displayName = user?.nickname?.trim() || user?.email || '게스트';
+  const subText = user?.nickname && user?.email ? user.email : null;
 
   return (
     <>
@@ -73,7 +87,7 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-3 py-2 space-y-0.5">
+        <div className="flex-1 overflow-y-auto px-3 py-2 space-y-0.5 min-h-0">
           {sessions.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-center">
               <MessageCircle size={28} strokeWidth={1} className="text-text-muted mb-3" />
@@ -121,6 +135,42 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
               );
             })
           )}
+        </div>
+
+        {/* 하단: 사용자 정보 + 설정 + 로그아웃 */}
+        <div className="border-t border-border px-3 py-2.5 shrink-0">
+          <div className="flex items-center gap-2.5 px-2 py-1.5">
+            <div className="w-7 h-7 rounded-lg bg-bg-subtle border border-border flex items-center justify-center shrink-0">
+              <User size={14} strokeWidth={1.8} className="text-text-secondary" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-[13px] font-medium text-text-primary truncate leading-tight">
+                {displayName}
+              </p>
+              {subText && (
+                <p className="text-[11px] text-text-muted truncate mt-0.5">{subText}</p>
+              )}
+            </div>
+            <Link
+              to="/settings"
+              onClick={onClose}
+              className="w-7 h-7 rounded-lg flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors cursor-pointer"
+              aria-label="설정"
+              title="설정"
+            >
+              <Settings size={14} strokeWidth={1.8} />
+            </Link>
+            {user && (
+              <button
+                onClick={handleLogout}
+                className="w-7 h-7 rounded-lg flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors cursor-pointer"
+                aria-label="로그아웃"
+                title="로그아웃"
+              >
+                <LogOut size={14} strokeWidth={1.8} />
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/src/components/chat/FeedbackButton.tsx
+++ b/src/components/chat/FeedbackButton.tsx
@@ -4,6 +4,7 @@
 import { useState } from 'react';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
 import { feedbackApi } from '@/lib/api';
+import { toast } from '@/stores/toastStore';
 import { cn } from '@/lib/utils';
 
 type Props = {
@@ -26,8 +27,9 @@ export default function FeedbackButton({ threadId, messageId }: Props) {
     try {
       await feedbackApi.create({ thread_id: threadId, message_id: messageId, rating: next });
       setRating(next);
-    } catch {
-      // 조용히 실패 — 토스트는 후속에서
+      toast.success('피드백이 전송되었어요');
+    } catch (e) {
+      toast.error((e as Error).message || '피드백 전송에 실패했습니다');
     } finally {
       setSubmitting(false);
     }

--- a/src/components/chat/ShareButton.tsx
+++ b/src/components/chat/ShareButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Share2, Check } from 'lucide-react';
 import { chatsApi } from '@/lib/api';
+import { toast } from '@/stores/toastStore';
 
 type Props = {
   threadId: string;
@@ -31,7 +32,6 @@ export default function ShareButton({ threadId }: Props) {
   const [copied, setCopied] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [shareUrl, setShareUrl] = useState<string | null>(null);
 
   const onClick = async () => {
     if (busy) return;
@@ -43,20 +43,21 @@ export default function ShareButton({ threadId }: Props) {
         ? res.share_url
         : `${window.location.origin}${res.share_url}`;
       const ok = await copyOrPrompt(url);
-      setShareUrl(url);
       if (ok) {
         setCopied(true);
+        toast.success('공유 링크를 복사했어요');
         setTimeout(() => setCopied(false), 2200);
+      } else {
+        toast.info('클립보드 권한이 없어 prompt로 표시했어요');
       }
     } catch (e) {
-      setError((e as Error).message || '공유 실패');
+      const msg = (e as Error).message || '공유 실패';
+      setError(msg);
+      toast.error(msg);
     } finally {
       setBusy(false);
     }
   };
-
-  // shareUrl 노출 처리는 부모에서 별도 — 여기선 가능한 범위 내 silent ok.
-  void shareUrl;
 
   return (
     <button

--- a/src/components/chat/blocks/ChartBlock.tsx
+++ b/src/components/chat/blocks/ChartBlock.tsx
@@ -35,7 +35,7 @@ export default function ChartBlock({ data }: { data: ChartBlockData }) {
               .map((a) => `${cx + Math.cos(a) * radius * r},${cy + Math.sin(a) * radius * r}`)
               .join(' ')}
             fill="none"
-            stroke="#D4CCB8"
+            stroke="var(--border)"
             strokeWidth={1}
           />
         ))}
@@ -46,8 +46,8 @@ export default function ChartBlock({ data }: { data: ChartBlockData }) {
           const ly = cy + Math.sin(a) * (radius + 18);
           return (
             <g key={m.key}>
-              <line x1={cx} y1={cy} x2={cx + Math.cos(a) * radius} y2={cy + Math.sin(a) * radius} stroke="#D4CCB8" />
-              <text x={lx} y={ly} textAnchor="middle" dominantBaseline="middle" fontSize={11} fill="#3A3A3A">
+              <line x1={cx} y1={cy} x2={cx + Math.cos(a) * radius} y2={cy + Math.sin(a) * radius} stroke="var(--border)" />
+              <text x={lx} y={ly} textAnchor="middle" dominantBaseline="middle" fontSize={11} fill="var(--text-primary)">
                 {m.label}
               </text>
             </g>

--- a/src/components/share/CalendarConnected.tsx
+++ b/src/components/share/CalendarConnected.tsx
@@ -1,0 +1,50 @@
+// Google Calendar OAuth 콜백 후 사용자가 보는 페이지.
+// BE 콜백(/api/v1/auth/google/calendar/callback)이 redirect 하도록 BE에 요청 필요.
+// 현재 BE는 JSON {message:"..."} 반환하므로 사용자가 raw 페이지를 봄.
+// 임시 대안: 사용자가 직접 이 URL로 돌아올 수 있는 안내.
+
+import { Link, useSearchParams } from 'react-router-dom';
+import { CheckCircle2, XCircle, ArrowRight } from 'lucide-react';
+import Button from '@/components/ui/Button';
+
+export default function CalendarConnected() {
+  const [params] = useSearchParams();
+  const error = params.get('error');
+  const success = !error;
+
+  return (
+    <div className="min-h-screen w-full flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md">
+        <div className="bg-bg-surface border-2 border-border-strong rounded-2xl p-8 shadow-[4px_4px_0_rgba(15,15,15,0.9)] text-center">
+          {success ? (
+            <>
+              <CheckCircle2 size={48} strokeWidth={1.5} className="text-[#6B8E5A] mx-auto mb-4" />
+              <h1 className="font-display text-2xl mb-2">연동 완료</h1>
+              <p className="text-sm text-text-secondary mb-6">
+                Google Calendar 연결이 완료되었어요.
+                이제 추천 일정을 본인 캘린더에 자동 등록할 수 있어요.
+              </p>
+            </>
+          ) : (
+            <>
+              <XCircle size={48} strokeWidth={1.5} className="text-brand mx-auto mb-4" />
+              <h1 className="font-display text-2xl mb-2">연동 실패</h1>
+              <p className="text-sm text-text-secondary mb-6">
+                {error === 'access_denied'
+                  ? '권한 요청을 취소했어요. 다시 시도하려면 설정에서 연동해 주세요.'
+                  : `오류가 발생했어요: ${error}`}
+              </p>
+            </>
+          )}
+          <Link to="/">
+            <Button>
+              <span className="inline-flex items-center gap-1.5">
+                메인으로 <ArrowRight size={14} />
+              </span>
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Toaster.tsx
+++ b/src/components/ui/Toaster.tsx
@@ -1,0 +1,75 @@
+// 토스트 렌더러 — Portal로 fixed 우상단에 stack.
+// DESIGN.md 톤: 크림 배경, 따뜻한 그림자, 네온 금지.
+
+import { useEffect, type ReactElement } from 'react';
+import { createPortal } from 'react-dom';
+import { X, CheckCircle2, AlertCircle, Info } from 'lucide-react';
+import { useToastStore, type ToastVariant } from '@/stores/toastStore';
+import { cn } from '@/lib/utils';
+
+const VARIANT_STYLES: Record<ToastVariant, { bg: string; border: string; icon: ReactElement }> = {
+  info: {
+    bg: 'bg-bg-surface',
+    border: 'border-border',
+    icon: <Info size={16} className="text-text-secondary" />,
+  },
+  success: {
+    bg: 'bg-bg-surface',
+    border: 'border-border',
+    icon: <CheckCircle2 size={16} className="text-[#6B8E5A]" />,
+  },
+  error: {
+    bg: 'bg-brand-subtle',
+    border: 'border-brand',
+    icon: <AlertCircle size={16} className="text-brand" />,
+  },
+};
+
+export default function Toaster() {
+  const toasts = useToastStore((s) => s.toasts);
+  const dismiss = useToastStore((s) => s.dismiss);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (!document.getElementById('toaster-root')) {
+      const root = document.createElement('div');
+      root.id = 'toaster-root';
+      document.body.appendChild(root);
+    }
+  }, []);
+
+  if (typeof document === 'undefined') return null;
+  const target = document.getElementById('toaster-root');
+  if (!target) return null;
+
+  return createPortal(
+    <div className="fixed top-4 right-4 z-[100] flex flex-col gap-2 pointer-events-none max-w-[360px]">
+      {toasts.map((t) => {
+        const v = VARIANT_STYLES[t.variant];
+        return (
+          <div
+            key={t.id}
+            role="status"
+            className={cn(
+              'flex items-start gap-2.5 px-3.5 py-2.5 rounded-xl border shadow-[2px_2px_0_rgba(15,15,15,0.9)] pointer-events-auto animate-message',
+              v.bg,
+              v.border,
+            )}
+          >
+            <div className="mt-0.5 shrink-0">{v.icon}</div>
+            <p className="flex-1 text-[13px] leading-snug text-text-primary">{t.message}</p>
+            <button
+              type="button"
+              onClick={() => dismiss(t.id)}
+              className="w-5 h-5 rounded flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-overlay transition-colors shrink-0"
+              aria-label="닫기"
+            >
+              <X size={12} />
+            </button>
+          </div>
+        );
+      })}
+    </div>,
+    target,
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,11 +5,13 @@ import App from './App';
 import './globals.css';
 import { useAuthStore } from '@/stores/authStore';
 import RequireAuth from '@/components/auth/RequireAuth';
+import Toaster from '@/components/ui/Toaster';
 
 const LoginPage = lazy(() => import('@/components/auth/LoginPage'));
 const SignupPage = lazy(() => import('@/components/auth/SignupPage'));
 const SettingsPage = lazy(() => import('@/components/settings/SettingsPage'));
 const SharedPage = lazy(() => import('@/components/share/SharedPage'));
+const CalendarConnected = lazy(() => import('@/components/share/CalendarConnected'));
 
 function Bootstrap() {
   const init = useAuthStore((s) => s.init);
@@ -19,11 +21,13 @@ function Bootstrap() {
 
   return (
     <BrowserRouter>
+      <Toaster />
       <Suspense fallback={null}>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
           <Route path="/shared/:token" element={<SharedPage />} />
+          <Route path="/calendar/connected" element={<CalendarConnected />} />
           <Route
             path="/settings"
             element={

--- a/src/mocks/agent-responses.ts
+++ b/src/mocks/agent-responses.ts
@@ -1,4 +1,5 @@
 import type { Message, Place, Itinerary, Booking } from '@/types';
+import type { Block } from '@/types/api';
 import placesData from './places.json';
 import itineraryData from './itinerary.json';
 
@@ -39,7 +40,14 @@ function matchPlaces(query: string): Place[] {
 export async function* streamResponse(
   text: string,
   query: string,
-): AsyncGenerator<{ text: string; done: boolean; places?: Place[]; itinerary?: Itinerary; booking?: Booking }> {
+): AsyncGenerator<{
+  text: string;
+  done: boolean;
+  places?: Place[];
+  itinerary?: Itinerary;
+  booking?: Booking;
+  blocks?: Block[];
+}> {
   // Simulate initial latency
   await new Promise((r) => setTimeout(r, 300 + Math.random() * 400));
 
@@ -48,8 +56,62 @@ export async function* streamResponse(
   let resultPlaces: Place[] | undefined;
   let resultItinerary: Itinerary | undefined;
   let resultBooking: Booking | undefined;
+  let resultBlocks: Block[] | undefined;
 
-  if (lower.includes('일정') || lower.includes('코스') || lower.includes('동선') || lower.includes('계획')) {
+  if (lower.includes('비교') || lower.includes('분석') || lower.includes('차트')) {
+    fullText = '두 곳을 6개 지표로 비교해봤어요. 만족도와 분위기는 비슷하지만 가성비는 차이가 큽니다.';
+    resultBlocks = [
+      {
+        type: 'chart',
+        chart_type: 'radar',
+        datasets: [
+          { label: '광장시장', score_satisfaction: 4.6, accessibility: 4.2, cleanliness: 3.5, value: 4.8, atmosphere: 4.7, expertise: 4.3 },
+          { label: '망원시장', score_satisfaction: 4.4, accessibility: 4.0, cleanliness: 3.8, value: 4.5, atmosphere: 4.5, expertise: 4.0 },
+        ],
+      },
+      {
+        type: 'analysis_sources',
+        review_count: 1240,
+        blog_count: 87,
+        official_count: 5,
+        sources: [
+          { source_type: 'review', snippet: '전 정말 맛있고 사장님 친절해요', url: 'https://example.com/r/1' },
+          { source_type: 'blog', snippet: '꼭 가봐야 할 서울 시장', url: 'https://example.com/b/2' },
+        ],
+      },
+    ];
+  } else if (lower.includes('행사') || lower.includes('축제') || lower.includes('이벤트')) {
+    fullText = '이번 달 서울에서 열리는 주요 행사 3건을 찾았어요.';
+    resultBlocks = [
+      {
+        type: 'events',
+        items: [
+          { event_id: 'ev-1', title: '서울빛초롱축제', district: '중구', place_name: '청계천', start_date: '2026-05-10', end_date: '2026-05-25', category: 'festival' },
+          { event_id: 'ev-2', title: '한강 야시장', district: '용산구', place_name: '여의도 한강공원', start_date: '2026-05-04', end_date: '2026-05-04', category: 'market' },
+          { event_id: 'ev-3', title: '서울국제도서전', district: '강남구', place_name: 'COEX', start_date: '2026-05-15', end_date: '2026-05-19', category: 'fair' },
+        ],
+        total_count: 3,
+      },
+      {
+        type: 'references',
+        items: [
+          { source_type: 'official', snippet: '문화체육관광부 후원 공식 행사', url: 'https://example.com/official' },
+        ],
+      },
+    ];
+  } else if (lower.includes('캘린더') || lower.includes('일정 등록') || lower.includes('등록해')) {
+    fullText = 'Google Calendar에 일정을 등록했어요.';
+    resultBlocks = [
+      {
+        type: 'calendar',
+        title: '광장시장 방문',
+        start_time: '2026-05-10T14:00:00+09:00',
+        end_time: '2026-05-10T16:00:00+09:00',
+        location: '서울특별시 종로구 창경궁로 88',
+        calendar_link: 'https://calendar.google.com',
+      },
+    ];
+  } else if (lower.includes('일정') || lower.includes('코스') || lower.includes('동선') || lower.includes('계획')) {
     const itin = itineraries[0];
     const stopNames = itin.stops.map((s) => s.placeName).join(' → ');
     fullText = `반나절 코스를 만들었어요! ${stopNames} 순서로 방문하시면 됩니다. 이동 시간까지 고려한 최적 동선이에요.`;
@@ -90,6 +152,7 @@ export async function* streamResponse(
     places: resultPlaces,
     itinerary: resultItinerary,
     booking: resultBooking,
+    blocks: resultBlocks,
   };
 }
 

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -3,6 +3,7 @@
 
 import { create } from 'zustand';
 import { authApi, getToken, setToken, setOnUnauthorized } from '@/lib/api';
+import { toast } from '@/stores/toastStore';
 import type { ApiUser, TokenResponse } from '@/types/api';
 
 type AuthUser = {
@@ -82,6 +83,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     const user = loadUser();
     set({ token, user, initialized: true });
     setOnUnauthorized(() => {
+      // 401이 처음 한 번만 토스트 — 이미 로그아웃된 상태면 silent
+      if (get().token) {
+        toast.error('세션이 만료되었습니다. 다시 로그인해 주세요.');
+      }
       get().logout();
     });
   },

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -75,11 +75,21 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
     try {
       const stream = streamResponse(text, text);
-      let finalData: { places?: Message['places']; itinerary?: Message['itinerary']; booking?: Message['booking'] } = {};
+      let finalData: {
+        places?: Message['places'];
+        itinerary?: Message['itinerary'];
+        booking?: Message['booking'];
+        blocks?: Message['blocks'];
+      } = {};
 
       for await (const chunk of stream) {
         if (chunk.done) {
-          finalData = { places: chunk.places, itinerary: chunk.itinerary, booking: chunk.booking };
+          finalData = {
+            places: chunk.places,
+            itinerary: chunk.itinerary,
+            booking: chunk.booking,
+            blocks: chunk.blocks,
+          };
         }
         set({ streamingText: chunk.text });
       }

--- a/src/stores/toastStore.ts
+++ b/src/stores/toastStore.ts
@@ -1,0 +1,50 @@
+// 미니 토스트 시스템 — zustand 큐 + 자동 dismiss.
+// Portal 렌더링은 src/components/ui/Toaster.tsx.
+
+import { create } from 'zustand';
+import { v4 as uuid } from 'uuid';
+
+export type ToastVariant = 'info' | 'success' | 'error';
+
+export type Toast = {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+  durationMs: number;
+};
+
+interface ToastStore {
+  toasts: Toast[];
+  push: (message: string, opts?: { variant?: ToastVariant; durationMs?: number }) => string;
+  dismiss: (id: string) => void;
+  clear: () => void;
+}
+
+export const useToastStore = create<ToastStore>((set) => ({
+  toasts: [],
+  push: (message, opts) => {
+    const id = uuid();
+    const toast: Toast = {
+      id,
+      message,
+      variant: opts?.variant ?? 'info',
+      durationMs: opts?.durationMs ?? 4000,
+    };
+    set((s) => ({ toasts: [...s.toasts, toast] }));
+    if (toast.durationMs > 0) {
+      window.setTimeout(() => {
+        useToastStore.getState().dismiss(id);
+      }, toast.durationMs);
+    }
+    return id;
+  },
+  dismiss: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+  clear: () => set({ toasts: [] }),
+}));
+
+// 외부에서 store import 없이 호출할 수 있는 단축 함수.
+export const toast = {
+  info: (msg: string, ms?: number) => useToastStore.getState().push(msg, { variant: 'info', durationMs: ms }),
+  success: (msg: string, ms?: number) => useToastStore.getState().push(msg, { variant: 'success', durationMs: ms }),
+  error: (msg: string, ms?: number) => useToastStore.getState().push(msg, { variant: 'error', durationMs: ms }),
+};


### PR DESCRIPTION
## Summary
- 사이드바 하단에 사용자(닉네임/이메일) + 설정 진입점 + 로그아웃 버튼
- 토스트 시스템 (zustand + Portal, 88 톤): info/success/error 3종
- 세션 만료 시 "세션이 만료되었습니다" 토스트 → 자동 logout
- Feedback/Share 버튼 silent fail → toast로 알림
- ChartBlock 하드코딩 색상 → CSS 변수
- Mock 데모 데이터: 키워드("비교/분석", "행사/축제", "캘린더 등록")로 새 SSE 블록 시각 검수 가능
- Google Calendar OAuth 콜백 후 안내 페이지 \`/calendar/connected\`

## 검수 방법
1. 채팅에 "두 시장 비교해줘" → chart + analysis_sources 블록
2. "이번달 행사 알려줘" → events + references
3. "캘린더에 등록해줘" → calendar 블록
4. 사이드바 좌측 햄버거 → 하단에 사용자/설정/로그아웃 노출 확인
5. 401 시뮬레이션 → 토스트 + /login 리다이렉트

## 관련
- 후속: BE \`/api/v1/auth/google/calendar/callback\`이 \`/calendar/connected\`로 redirect 하도록 협의 필요 (현재 JSON 반환 → 사용자가 raw 페이지 봄)

## 체크리스트
- [x] tsc + vite build green
- [x] DESIGN.md 톤 (크림 배경, 88 그림자, 네온 금지) 준수
- [x] AGENTS.md 브랜치 규칙 (\`feat/...\`) 준수

🤖 Generated with [Claude Code](https://claude.com/claude-code)