### PR TITLE
feat: 일정 탭에 Google Calendar 연동 버튼 추가

### DIFF
--- a/src/components/calendar/CalendarPanel.tsx
+++ b/src/components/calendar/CalendarPanel.tsx
@@ -1,21 +1,57 @@
-
-
-import { Calendar, Download } from 'lucide-react';
+import { useState } from 'react';
+import { Calendar, Download, Link2 } from 'lucide-react';
 import { useCalendarStore } from '@/stores/calendarStore';
 import { TRANSPORT_LABELS } from '@/lib/utils';
 import { downloadICS } from '@/lib/ics-export';
+import { googleCalendarApi } from '@/lib/api';
+import { toast } from '@/stores/toastStore';
 import EmptyState from '@/components/ui/EmptyState';
 import type { Itinerary } from '@/types';
+
+function GoogleCalendarConnectBar() {
+  const [busy, setBusy] = useState(false);
+  const onConnect = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const { auth_url } = await googleCalendarApi.getAuthUrl();
+      window.location.href = auth_url;
+    } catch (e) {
+      toast.error((e as Error).message || '연동 URL을 불러올 수 없습니다');
+      setBusy(false);
+    }
+  };
+  return (
+    <div className="px-3 pt-3">
+      <button
+        onClick={onConnect}
+        disabled={busy}
+        className="w-full flex items-center justify-center gap-1.5 py-2.5 rounded-xl border border-border bg-bg-surface hover:border-border-strong hover:bg-bg-subtle transition-colors text-[12px] font-medium text-text-primary disabled:opacity-60 cursor-pointer"
+      >
+        <Link2 size={13} />
+        {busy ? '이동 중...' : 'Google Calendar 연동'}
+      </button>
+    </div>
+  );
+}
 
 export default function CalendarPanel() {
   const { events, removeEvent } = useCalendarStore();
 
   if (events.length === 0) {
-    return <EmptyState icon={Calendar} title="일정 없음" description="에이전트에게 일정을 만들어달라고 해보세요" />;
+    return (
+      <div className="h-full flex flex-col">
+        <GoogleCalendarConnectBar />
+        <div className="flex-1 flex items-center justify-center">
+          <EmptyState icon={Calendar} title="일정 없음" description="에이전트에게 일정을 만들어달라고 해보세요" />
+        </div>
+      </div>
+    );
   }
 
   return (
     <div className="h-full overflow-y-auto p-3 space-y-3">
+      <GoogleCalendarConnectBar />
       {events.map((event) => (
         <div key={event.id} className="bg-bg-surface border border-border rounded-2xl overflow-hidden animate-fade-up">
           <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-bg-subtle/50">


### PR DESCRIPTION
## Summary
헤더의 "일정" 탭(\`CalendarPanel\`)이 원래 Google Calendar 연동 기획이었던 점 반영. 설정 페이지의 동일 버튼은 유지 (진입점 2개).

## 변경
- \`src/components/calendar/CalendarPanel.tsx\`에 상단 연동 버튼 추가
- 빈 상태/이벤트 있는 상태 모두 노출
- \`googleCalendarApi.getAuthUrl()\` 호출 → \`auth_url\`로 \`window.location.href\` 리다이렉트
- 실패 시 toast 알림

## 검수
1. 메인 → 우상단 "일정" 탭 클릭 → 패널 상단에 "Google Calendar 연동" 버튼 노출
2. 클릭 → MSW가 mock auth_url 발급 → \`/calendar/connected?mock=1\` 으로 리다이렉트 → 성공 페이지

🤖 Generated with [Claude Code](https://claude.com/claude-code)