### PR TITLE
fix: 대화 북마크 버튼을 액션 행으로 이동 — 호버 의존 제거

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -50,27 +50,8 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
         <div className="group/bubble relative flex gap-2.5 pr-4">
           <AgentMark agent={agent} size={28} className="mt-0.5" />
 
-          {/* Bookmark toggle — hover reveal (always visible when bookmarked) */}
-          <button
-            type="button"
-            onClick={handleBookmark}
-            className={`absolute top-0 right-0 w-7 h-7 rounded-full flex items-center justify-center transition-all duration-200 cursor-pointer ${
-              isMessageBookmarked
-                ? 'opacity-100 bg-amber-50 text-amber-600'
-                : 'opacity-0 group-hover/bubble:opacity-100 bg-bg-surface border border-border text-text-muted hover:text-text-primary hover:border-border-strong'
-            }`}
-            aria-label={isMessageBookmarked ? '대화 북마크 해제' : '대화 북마크'}
-            aria-pressed={isMessageBookmarked}
-          >
-            <Bookmark
-              size={13}
-              strokeWidth={isMessageBookmarked ? 0 : 1.8}
-              fill={isMessageBookmarked ? '#F59E0B' : 'none'}
-            />
-          </button>
-
           <div className="flex-1 min-w-0 space-y-2">
-            <div className="text-[14px] leading-[1.7] text-text-primary pr-8">
+            <div className="text-[14px] leading-[1.7] text-text-primary">
               {message.text}
             </div>
 
@@ -89,12 +70,33 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
               </div>
             )}
 
-            {message.threadId && message.messageId != null && String(message.messageId).length > 0 && (
-              <div className="flex items-center gap-1 pt-1">
-                <FeedbackButton threadId={message.threadId} messageId={message.messageId} />
-                <ShareButton threadId={message.threadId} />
-              </div>
-            )}
+            {/* 어시스턴트 메시지 액션 행 — 항상 노출 (호버/터치 모두 접근 가능) */}
+            <div className="flex items-center gap-1 pt-1">
+              <button
+                type="button"
+                onClick={handleBookmark}
+                className={`inline-flex items-center gap-1 px-2 py-1 rounded transition-colors cursor-pointer text-xs ${
+                  isMessageBookmarked
+                    ? 'text-amber-600 bg-amber-50 hover:bg-amber-100'
+                    : 'text-text-muted hover:text-text-primary hover:bg-bg-overlay'
+                }`}
+                aria-label={isMessageBookmarked ? '대화 북마크 해제' : '대화 북마크'}
+                aria-pressed={isMessageBookmarked}
+              >
+                <Bookmark
+                  size={14}
+                  strokeWidth={isMessageBookmarked ? 0 : 1.8}
+                  fill={isMessageBookmarked ? '#F59E0B' : 'none'}
+                />
+                <span>{isMessageBookmarked ? '저장됨' : '저장'}</span>
+              </button>
+              {message.threadId && message.messageId != null && String(message.messageId).length > 0 && (
+                <>
+                  <FeedbackButton threadId={message.threadId} messageId={message.messageId} />
+                  <ShareButton threadId={message.threadId} />
+                </>
+              )}
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
어시스턴트 메시지의 북마크 아이콘이 호버 시에만 노출돼 발견성이 낮고 터치 디바이스에서 안 보였던 문제 수정.

## 변경
- 우상단 absolute → 메시지 하단 액션 행 (Feedback/Share와 같은 줄)
- \`opacity-0 group-hover\` → 항상 노출
- 텍스트 라벨 "저장"/"저장됨" 추가 — 아이콘만 있을 때보다 의도 명확

## 검수
- 채팅 응답 후 어시스턴트 버블 하단에 "저장" 버튼이 항상 노출되는지
- 클릭 → "저장됨" + 우상단 북마크 탭 카운트 +1
- 다시 클릭 → 토글 해제

🤖 Generated with [Claude Code](https://claude.com/claude-code)