### PR TITLE
feat: mock 응답에 이미지 추가 — 코스/장소 카드 시각 개선

### DIFF
--- a/src/components/chat/PlaceCard.tsx
+++ b/src/components/chat/PlaceCard.tsx
@@ -35,6 +35,18 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
         className="group bg-bg-surface border border-border rounded-2xl overflow-hidden transition-[border-color,box-shadow,transform] duration-200 hover:shadow-md hover:border-border-strong hover:-translate-y-[1px]"
       >
         <div className="relative aspect-video bg-bg-subtle overflow-hidden">
+          {place.image && (
+            <img
+              src={place.image}
+              alt={place.name}
+              loading="lazy"
+              className="absolute inset-0 w-full h-full object-cover"
+              onError={(e) => {
+                // 이미지 로드 실패 시 카테고리 색 placeholder로 대체
+                (e.currentTarget as HTMLImageElement).style.display = 'none';
+              }}
+            />
+          )}
           <span
             className="absolute top-3 left-3 z-10 px-2 py-0.5 rounded-full text-[11px] font-medium"
             style={{ backgroundColor: `${cat.color}14`, color: cat.color }}

--- a/src/mocks/msw/handlers.ts
+++ b/src/mocks/msw/handlers.ts
@@ -289,8 +289,8 @@ function buildSseStream(query: string, threadId: string): ReadableStream<Uint8Ar
         send('places', {
           type: 'places',
           items: [
-            { place_id: 'p1', name: '광장시장', category: 'food', address: '종로구 창경궁로 88', district: '종로구', lat: 37.5703, lng: 126.9990, rating: 4.5 },
-            { place_id: 'p2', name: '망원시장', category: 'food', address: '마포구 포은로8길', district: '마포구', lat: 37.5560, lng: 126.9056, rating: 4.3 },
+            { place_id: 'p1', name: '광장시장', category: 'food', address: '종로구 창경궁로 88', district: '종로구', lat: 37.5703, lng: 126.9990, rating: 4.5, image_url: 'https://picsum.photos/seed/seoul-gwangjang-market/640/360' },
+            { place_id: 'p2', name: '망원시장', category: 'food', address: '마포구 포은로8길', district: '마포구', lat: 37.5560, lng: 126.9056, rating: 4.3, image_url: 'https://picsum.photos/seed/seoul-mangwon-market/640/360' },
           ],
           total_count: 2,
         });
@@ -307,9 +307,9 @@ function buildSseStream(query: string, threadId: string): ReadableStream<Uint8Ar
           type: 'course',
           title: '종로 반나절 코스',
           stops: [
-            { order: 1, place_id: 'p1', name: '광장시장', lat: 37.5703, lng: 126.9990, duration_minutes: 60, memo: '빈대떡' },
-            { order: 2, place_id: 'p3', name: '경복궁', lat: 37.5796, lng: 126.9770, duration_minutes: 90, memo: '한복 체험' },
-            { order: 3, place_id: 'p4', name: '북촌한옥마을', lat: 37.5826, lng: 126.9836, duration_minutes: 60, memo: '산책' },
+            { order: 1, place_id: 'p1', name: '광장시장', lat: 37.5703, lng: 126.9990, duration_minutes: 60, memo: '빈대떡', image_url: 'https://picsum.photos/seed/seoul-gwangjang-market/640/360' },
+            { order: 2, place_id: 'p3', name: '경복궁', lat: 37.5796, lng: 126.9770, duration_minutes: 90, memo: '한복 체험', image_url: 'https://picsum.photos/seed/seoul-gyeongbokgung-palace/640/360' },
+            { order: 3, place_id: 'p4', name: '북촌한옥마을', lat: 37.5826, lng: 126.9836, duration_minutes: 60, memo: '산책', image_url: 'https://picsum.photos/seed/seoul-bukchon-hanok/640/360' },
           ],
           total_duration_minutes: 210,
         });
@@ -337,9 +337,9 @@ function buildSseStream(query: string, threadId: string): ReadableStream<Uint8Ar
         send('events', {
           type: 'events',
           items: [
-            { event_id: 'e1', title: '서울빛초롱축제', district: '중구', place_name: '청계천', start_date: '2026-05-10', end_date: '2026-05-25', category: 'festival' },
-            { event_id: 'e2', title: '한강 야시장', district: '용산구', place_name: '여의도 한강공원', start_date: '2026-05-04', end_date: '2026-05-04', category: 'market' },
-            { event_id: 'e3', title: '서울국제도서전', district: '강남구', place_name: 'COEX', start_date: '2026-05-15', end_date: '2026-05-19', category: 'fair' },
+            { event_id: 'e1', title: '서울빛초롱축제', district: '중구', place_name: '청계천', start_date: '2026-05-10', end_date: '2026-05-25', category: 'festival', image_url: 'https://picsum.photos/seed/seoul-lantern-festival/320/240' },
+            { event_id: 'e2', title: '한강 야시장', district: '용산구', place_name: '여의도 한강공원', start_date: '2026-05-04', end_date: '2026-05-04', category: 'market', image_url: 'https://picsum.photos/seed/seoul-han-market/320/240' },
+            { event_id: 'e3', title: '서울국제도서전', district: '강남구', place_name: 'COEX', start_date: '2026-05-15', end_date: '2026-05-19', category: 'fair', image_url: 'https://picsum.photos/seed/seoul-bookfair/320/240' },
           ],
           total_count: 3,
         });

--- a/src/mocks/places.json
+++ b/src/mocks/places.json
@@ -9,7 +9,7 @@
     "hours": "09:00 - 18:00 (화요일 휴무)",
     "rating": 4.8,
     "summary": "조선 왕조의 정궁으로, 근정전과 경회루 등 웅장한 건축미를 감상할 수 있는 서울 대표 관광지입니다.",
-    "image": "/places/gyeongbokgung.jpg",
+    "image": "https://picsum.photos/seed/seoul-gyeongbokgung-palace/640/360",
     "congestion": {
       "level": "high",
       "updatedAt": "2026-04-14T10:00:00Z"
@@ -25,7 +25,7 @@
     "hours": "상시 개방",
     "rating": 4.5,
     "summary": "600년 역사의 한옥이 밀집한 마을로, 전통 건축과 현대 갤러리가 공존하는 문화 명소입니다.",
-    "image": "/places/bukchon.jpg",
+    "image": "https://picsum.photos/seed/seoul-bukchon-hanok/640/360",
     "congestion": {
       "level": "high",
       "updatedAt": "2026-04-14T10:00:00Z"
@@ -41,7 +41,7 @@
     "hours": "09:00 - 22:00",
     "rating": 4.6,
     "summary": "100년 역사의 전통시장. 빈대떡, 마약김밥, 육회 등 한국 길거리 음식의 성지입니다.",
-    "image": "/places/gwangjang.jpg",
+    "image": "https://picsum.photos/seed/seoul-gwangjang-market/640/360",
     "congestion": {
       "level": "medium",
       "updatedAt": "2026-04-14T10:00:00Z"
@@ -57,7 +57,7 @@
     "hours": "10:00 - 22:00",
     "rating": 4.3,
     "summary": "K-뷰티, 패션, 액세서리 브랜드가 밀집한 서울 최대 쇼핑 거리입니다.",
-    "image": "/places/myeongdong.jpg",
+    "image": "https://picsum.photos/seed/seoul-myeongdong-street/640/360",
     "congestion": {
       "level": "medium",
       "updatedAt": "2026-04-14T10:00:00Z"
@@ -73,7 +73,7 @@
     "hours": "10:00 - 23:00",
     "rating": 4.7,
     "summary": "서울의 상징적인 타워로, 360도 파노라마 야경을 감상할 수 있는 전망대입니다.",
-    "image": "/places/namsan.jpg",
+    "image": "https://picsum.photos/seed/seoul-namsan-tower/640/360",
     "congestion": {
       "level": "low",
       "updatedAt": "2026-04-14T10:00:00Z"
@@ -89,7 +89,7 @@
     "hours": "10:30 - 20:30",
     "rating": 4.4,
     "summary": "전통 공예, 아트샵, 갤러리가 모인 나선형 복합문화공간입니다.",
-    "image": "/places/insadong.jpg",
+    "image": "https://picsum.photos/seed/seoul-insadong-alley/640/360",
     "congestion": {
       "level": "low",
       "updatedAt": "2026-04-14T10:00:00Z"
@@ -105,7 +105,7 @@
     "hours": "11:00 - 21:00",
     "rating": 4.5,
     "summary": "을지로 골목의 오래된 맛집들을 탐방하는 힙레트로 코스입니다.",
-    "image": "/places/euljiro.jpg",
+    "image": "https://picsum.photos/seed/seoul-euljiro-night/640/360",
     "congestion": {
       "level": "high",
       "updatedAt": "2026-04-14T10:00:00Z"
@@ -121,7 +121,7 @@
     "hours": "11:00 - 22:00",
     "rating": 4.6,
     "summary": "리노베이션 공장 카페, 팝업스토어, 디자이너 브랜드가 밀집한 힙 플레이스입니다.",
-    "image": "/places/seongsu.jpg",
+    "image": "https://picsum.photos/seed/seoul-seongsu-cafe/640/360",
     "congestion": {
       "level": "medium",
       "updatedAt": "2026-04-14T10:00:00Z"


### PR DESCRIPTION
## 문제
\`places.json\`의 \`image\` 경로가 \`/places/*.jpg\`인데 \`public/places/\` 디렉토리 자체가 없음 → PlaceCard/ItineraryCard에서 깨진 이미지 노출.

## 변경
- \`places.json\` 8개 image를 \`picsum.photos\` seeded URL로 교체 (시드 고정 → 동일 장소는 동일 이미지)
- \`PlaceCard\`에 \`<img>\` 추가 (이전엔 빈 영역만 있었음), \`onError\` 시 디스플레이 숨김으로 폴백
- MSW SSE 핸들러의 places/course/events 응답에 \`image_url\` 추가

## 참고
현재 채팅 입력은 레거시 \`useChatStore\` 사용 중이라 MSW SSE는 발화 안 됨. 보이는 코스 응답은 레거시 \`itinerary.json\` + \`places.json\` 결과 → 이번 패치로 이미지 노출됨. \`apiChatStore\`를 App.tsx에 wiring하는 task #4 완료 시 MSW SSE 흐름에서도 이미지 노출 (이미 핸들러는 image_url 포함).

## 검수
1. 채팅 "맛집 추천해줘" → PlaceCard에 이미지 노출
2. 채팅 "일정 짜줘" → ItineraryCard 좌측 이미지 노출
3. 외부 picsum.photos 차단된 환경이면 onError → placeholder 영역만 보임

🤖 Generated with [Claude Code](https://claude.com/claude-code)