### PR TITLE
feat: BE dev 신규 반영 — 북마크 REST + DETAIL_INQUIRY intent

### DIFF
--- a/apispec/API_SPEC.md
+++ b/apispec/API_SPEC.md
@@ -5,7 +5,7 @@
 
 ---
 
-## BE 구현 현황 (agt-backend `dev` 기준, 2026-05-01 sync)
+## BE 구현 현황 (agt-backend `dev` 기준, 2026-05-01 sync · 2회차 업데이트)
 
 | 엔드포인트 | 상태 | 비고 |
 |---|---|---|
@@ -26,11 +26,12 @@
 | `DELETE /api/v1/chats/{id}/share` | ✅ | revoke |
 | `GET /shared/{token}` | ✅ | 인증 불필요 |
 | `GET /api/v1/chat/stream` | 🟡 | 라우트 존재, 본체는 stub (현재 `done`만 즉시 전송, JWT 미검증, LangGraph 미연결) |
-| `POST /api/v1/users/me/bookmarks` | ❌ | 북마크 모듈 BE에 없음 |
-| `GET /api/v1/users/me/bookmarks` | ❌ | 동일 |
-| `DELETE /api/v1/users/me/bookmarks/{id}` | ❌ | 동일 |
+| `POST /api/v1/users/me/bookmarks` | ✅ | BIGSERIAL bookmark_id, message_id int |
+| `GET /api/v1/users/me/bookmarks` | ✅ | filter: thread_id/pin_type, cursor 페이지네이션 |
+| `DELETE /api/v1/users/me/bookmarks/{id}` | ✅ | 소프트 삭제 (is_deleted=true) |
 | `POST /api/v1/feedback` | ❌ | feedback 모듈 BE에 없음 |
-| (그 외 SSE intent별 응답 패턴들) | 🟡 | sse.py가 stub 단계라 모든 intent가 즉시 done |
+| SSE intent: DETAIL_INQUIRY | ✅ | 단건 장소 상세 조회 (text_stream + place 단일) |
+| (그 외 SSE intent별 응답 패턴들) | 🟡 | sse.py가 stub 단계라 BE 직접 호출 시 즉시 done |
 
 **범례**: ✅ 사용 가능 / 🟡 라우트만 / ❌ BE 자체 없음
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -227,8 +227,7 @@ export const googleCalendarApi = {
   getAuthUrl: () => request<{ auth_url: string }>('/api/v1/auth/google/calendar'),
 };
 
-// ⚠️ BE 미구현 — 북마크 모듈 자체가 backend/src/api/에 없음.
-//   호출 시 모두 404. BE 구현 전엔 useApiBookmarkStore 활성화 금지.
+// 북마크 — BE dev 구현 완료 (3 endpoints, soft delete).
 export const bookmarksApi = {
   create: (body: BookmarkCreateRequest) =>
     request<BookmarkCreateResponse>('/api/v1/users/me/bookmarks', {
@@ -237,8 +236,8 @@ export const bookmarksApi = {
     }),
   list: (params?: { thread_id?: string; pin_type?: PinType; cursor?: string; limit?: number }) =>
     request<BookmarkListResponse>(buildUrl('/api/v1/users/me/bookmarks', params)),
-  delete: (bookmark_id: string) =>
-    request<void>(`/api/v1/users/me/bookmarks/${encodeURIComponent(bookmark_id)}`, { method: 'DELETE' }),
+  delete: (bookmark_id: string | number) =>
+    request<void>(`/api/v1/users/me/bookmarks/${encodeURIComponent(String(bookmark_id))}`, { method: 'DELETE' }),
 };
 
 export const chatsApi = {

--- a/src/mocks/msw/handlers.ts
+++ b/src/mocks/msw/handlers.ts
@@ -32,10 +32,10 @@ type MessageRow = {
   created_at: string;
 };
 type BookmarkRow = {
-  bookmark_id: string;
+  bookmark_id: number; // BE는 BIGSERIAL int
   thread_id: string;
   thread_title: string | null;
-  message_id: string;
+  message_id: number; // BE는 int
   pin_type: PinType;
   preview_text: string | null;
   created_at: string;
@@ -46,6 +46,7 @@ const messages: MessageRow[] = [];
 const bookmarks: BookmarkRow[] = [];
 const shares = new Map<string, { thread_id: string; created_at: string }>();
 let messageSeq = 1;
+let bookmarkSeq = 1;
 
 const MOCK_USER = { user_id: 1, email: 'demo@seoul.app', nickname: 'demo', auth_provider: 'email' };
 const MOCK_TOKEN = 'mock.jwt.token';
@@ -204,22 +205,29 @@ export const restHandlers = [
   http.post('/api/v1/users/me/bookmarks', async ({ request }) => {
     const body = (await request.json()) as BookmarkCreateRequest;
     const row: BookmarkRow = {
-      bookmark_id: uuid(),
+      bookmark_id: bookmarkSeq++,
       thread_id: body.thread_id,
       thread_title: chats.get(body.thread_id)?.title ?? null,
-      message_id: String(body.message_id),
+      message_id: Number(body.message_id) || 0,
       pin_type: body.pin_type,
       preview_text: body.preview_text ?? null,
       created_at: nowIso(),
     };
     bookmarks.unshift(row);
     return HttpResponse.json(
-      { bookmark_id: row.bookmark_id, pin_type: row.pin_type, preview_text: row.preview_text, created_at: row.created_at },
+      {
+        bookmark_id: row.bookmark_id,
+        thread_id: row.thread_id,
+        message_id: row.message_id,
+        pin_type: row.pin_type,
+        preview_text: row.preview_text,
+        created_at: row.created_at,
+      },
       { status: 201 },
     );
   }),
   http.delete('/api/v1/users/me/bookmarks/:id', ({ params }) => {
-    const id = String(params.id);
+    const id = Number(params.id);
     const idx = bookmarks.findIndex((b) => b.bookmark_id === id);
     if (idx >= 0) bookmarks.splice(idx, 1);
     return new HttpResponse(null, { status: 204 });
@@ -242,8 +250,11 @@ function sseFrame(event: string, data: unknown): string {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
 }
 
-function pickIntent(query: string): 'GENERAL' | 'PLACE_SEARCH' | 'COURSE_PLAN' | 'CALENDAR' | 'EVENT' | 'ANALYSIS' {
+function pickIntent(query: string): 'GENERAL' | 'PLACE_SEARCH' | 'COURSE_PLAN' | 'CALENDAR' | 'EVENT' | 'ANALYSIS' | 'DETAIL_INQUIRY' {
   const q = query.toLowerCase();
+  // DETAIL_INQUIRY: "거기/그 장소/여기 영업시간/주소/전화" 등 단건 상세 질문
+  if (/(거기|여기|그\s*장소|그곳).*?(어때|영업|주소|전화|시간|얼마|메뉴|평점)/.test(q)) return 'DETAIL_INQUIRY';
+  if (/영업시간|운영시간|상세|자세히/.test(q) && q.length < 40) return 'DETAIL_INQUIRY';
   if (/비교|분석|차트/.test(q)) return 'ANALYSIS';
   if (/행사|축제|이벤트/.test(q)) return 'EVENT';
   if (/캘린더|일정\s*등록|등록해/.test(q)) return 'CALENDAR';
@@ -277,6 +288,7 @@ function buildSseStream(query: string, threadId: string): ReadableStream<Uint8Ar
         CALENDAR: 'Google Calendar에 일정을 등록했어요.',
         EVENT: '이번 달 서울 행사 3건을 찾았어요.',
         ANALYSIS: '두 곳을 6지표로 비교했어요. 가성비 차이가 큽니다.',
+        DETAIL_INQUIRY: '광장시장은 종로구 창경궁로에 위치한 100년 전통 시장입니다. 빈대떡과 마약김밥이 유명하고 평점은 4.5예요.',
       };
       const reply = replyMap[intent];
       for (const ch of reply) {
@@ -347,6 +359,20 @@ function buildSseStream(query: string, threadId: string): ReadableStream<Uint8Ar
         send('references', {
           type: 'references',
           items: [{ source_type: 'official', snippet: '문화체육관광부 후원 공식 행사', url: 'https://example.com' }],
+        });
+      } else if (intent === 'DETAIL_INQUIRY') {
+        send('place', {
+          type: 'place',
+          place_id: 'p1',
+          name: '광장시장',
+          category: 'food',
+          address: '서울특별시 종로구 창경궁로 88',
+          district: '종로구',
+          lat: 37.5703,
+          lng: 126.9990,
+          rating: 4.5,
+          image_url: 'https://picsum.photos/seed/seoul-gwangjang-market/640/360',
+          summary: '100년 역사의 전통시장. 빈대떡, 마약김밥, 육회 등 길거리 음식의 성지.',
         });
       } else if (intent === 'ANALYSIS') {
         send('chart', {

--- a/src/stores/apiBookmarkStore.ts
+++ b/src/stores/apiBookmarkStore.ts
@@ -12,7 +12,7 @@ interface ApiBookmarkStore {
   loaded: boolean;
   load: (filter?: { thread_id?: string; pin_type?: PinType }) => Promise<void>;
   add: (input: { thread_id: string; message_id: string | number; pin_type: PinType; preview_text?: string }) => Promise<void>;
-  remove: (bookmark_id: string) => Promise<void>;
+  remove: (bookmark_id: string | number) => Promise<void>;
   isBookmarked: (message_id: string | number, thread_id: string) => boolean;
   findByMessage: (message_id: string | number, thread_id: string) => BookmarkItem | undefined;
 }
@@ -84,11 +84,11 @@ export const useApiBookmarkStore = create<ApiBookmarkStore>((set, get) => ({
 
   isBookmarked: (message_id, thread_id) => {
     const mid = String(message_id);
-    return get().items.some((b) => b.message_id === mid && b.thread_id === thread_id);
+    return get().items.some((b) => String(b.message_id) === mid && b.thread_id === thread_id);
   },
 
   findByMessage: (message_id, thread_id) => {
     const mid = String(message_id);
-    return get().items.find((b) => b.message_id === mid && b.thread_id === thread_id);
+    return get().items.find((b) => String(b.message_id) === mid && b.thread_id === thread_id);
   },
 }));

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,25 +1,30 @@
 import { create } from 'zustand';
 import type { AgentType, Message, Place, Itinerary, PlaceCategory, TransportMode } from '@/types';
-import type { Block, PlacesBlock, CourseBlock } from '@/types/api';
+import type { Block, PlaceBlockData, PlacesBlock, CourseBlock } from '@/types/api';
 import { getWelcomeMessage } from '@/mocks/agent-responses';
 import { openChatStream } from '@/lib/sse';
 import { useMapStore } from './mapStore';
 
 // SSE 블록 → 레거시 Message 타입 어댑터.
-function placesBlockToPlaces(block: PlacesBlock): Place[] {
-  const allowedCats: PlaceCategory[] = ['tourism', 'shopping', 'culture', 'food'];
-  return block.items.map((it) => ({
+const ALLOWED_CATS: PlaceCategory[] = ['tourism', 'shopping', 'culture', 'food'];
+
+function singlePlaceBlockToPlace(it: PlaceBlockData): Place {
+  return {
     id: it.place_id,
     name: it.name,
-    category: (allowedCats.includes(it.category as PlaceCategory) ? it.category : 'tourism') as PlaceCategory,
+    category: (ALLOWED_CATS.includes(it.category as PlaceCategory) ? it.category : 'tourism') as PlaceCategory,
     address: it.address ?? '',
     lat: it.lat ?? 0,
     lng: it.lng ?? 0,
     hours: '',
     rating: it.rating ?? 0,
     summary: it.summary ?? '',
-    image: (it as { image_url?: string }).image_url,
-  }));
+    image: it.image_url,
+  };
+}
+
+function placesBlockToPlaces(block: PlacesBlock): Place[] {
+  return block.items.map((it) => singlePlaceBlockToPlace({ ...it, type: 'place' }));
 }
 
 function courseBlockToItinerary(block: CourseBlock): Itinerary {
@@ -137,6 +142,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         places: (data) => {
           if (data.type === 'places') {
             places = placesBlockToPlaces(data);
+          }
+        },
+        place: (data) => {
+          // DETAIL_INQUIRY 단건 응답 — places 배열에 1건만 채움.
+          if (data.type === 'place') {
+            places = [singlePlaceBlockToPlace(data)];
           }
         },
         course: (data) => {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -23,10 +23,11 @@ export type TokenResponse = {
 export type PinType = 'place' | 'event' | 'course' | 'analysis' | 'general';
 
 export type BookmarkItem = {
-  bookmark_id: string;
+  // BE는 BIGSERIAL int로 직렬화. 직렬화 가이드는 string이지만 양쪽 수용.
+  bookmark_id: string | number;
   thread_id: string;
-  thread_title: string | null;
-  message_id: string;
+  thread_title?: string | null; // BE 응답에 미포함, 클라이언트가 채울 수 있음
+  message_id: string | number;
   pin_type: PinType;
   preview_text: string | null;
   created_at: string;
@@ -45,7 +46,9 @@ export type BookmarkCreateRequest = {
 };
 
 export type BookmarkCreateResponse = {
-  bookmark_id: string;
+  bookmark_id: string | number;
+  thread_id?: string;
+  message_id?: string | number;
   pin_type: PinType;
   preview_text: string | null;
   created_at: string;


### PR DESCRIPTION
## Summary
BE \`dev\` 브랜치에 새로 머지된 2가지 기능 반영.

### BE 신규 (PR #32, #34)
1. **북마크 REST API 3종**: GET/POST/DELETE \`/api/v1/users/me/bookmarks\` — soft delete, cursor 페이지네이션
2. **DETAIL_INQUIRY SSE intent**: 단건 장소 상세 조회 (text_stream + 단일 \`place\` 블록)

## FE 변경
- \`types/api.ts\`: \`BookmarkItem.bookmark_id\`/\`message_id\` → \`string | number\` (BE BIGSERIAL int 호환)
- \`lib/api.ts\`: \`bookmarksApi\`의 "BE 미구현" 주석 제거, \`delete()\`가 number도 수용
- \`stores/apiBookmarkStore.ts\`: ID 비교 시 \`String()\` 정규화
- \`stores/chatStore.ts\`: SSE \`place\` 단건 핸들러 추가 → \`places[1]\`로 PlaceCarousel 렌더
- \`mocks/msw/handlers.ts\`:
  - bookmarks를 BIGSERIAL 시뮬레이션
  - DETAIL_INQUIRY 패턴 추가 ("거기/여기 영업시간/어때/주소" 등)
- \`apispec/API_SPEC.md\`: bookmarks ❌→✅, DETAIL_INQUIRY ✅

## 검수
- 채팅 "광장시장 영업시간 알려줘" → 단건 PlaceCard 노출
- 채팅 "거기 어때?" → DETAIL_INQUIRY 발화 → 단건 카드
- 북마크 추가/삭제 → MSW가 BE 형식대로 응답 → 화면 반영

## 체크리스트
- [x] tsc green / vite build green / 테스트 13건 pass
- [x] BE \`dev\` HEAD c7d8500 기준 정렬

🤖 Generated with [Claude Code](https://claude.com/claude-code)