### PR TITLE
feat: 트렌디 인터랙션 — 슬라이딩 인디케이터 + 오버레이 exit + 탭 cross-fade

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,8 +30,19 @@ const NAV_ITEMS: { key: Exclude<Overlay, null>; label: string; icon: typeof MapP
 function NavButtons({
   overlay, onSelect, bookmarkCount,
 }: { overlay: Overlay; onSelect: (key: Overlay) => void; bookmarkCount: number }) {
+  // 슬라이딩 인디케이터 — Linear/Vercel 스타일.
+  // 버튼 36px(w-9) + gap 2px(gap-0.5) → 인덱스당 38px translateX.
+  const activeIndex = overlay ? NAV_ITEMS.findIndex((n) => n.key === overlay) : -1;
   return (
-    <div className="flex items-center gap-0.5">
+    <div className="relative flex items-center gap-0.5">
+      <span
+        aria-hidden
+        className="pointer-events-none absolute top-0 left-0 w-9 h-9 rounded-xl bg-brand-subtle transition-[transform,opacity] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+        style={{
+          transform: `translateX(${Math.max(activeIndex, 0) * 38}px)`,
+          opacity: activeIndex >= 0 ? 1 : 0,
+        }}
+      />
       {NAV_ITEMS.map((item) => {
         const Icon = item.icon;
         const isActive = overlay === item.key;
@@ -41,18 +52,19 @@ function NavButtons({
             key={item.key}
             onClick={() => onSelect(isActive ? null : item.key)}
             className={cn(
-              'relative w-9 h-9 rounded-xl flex items-center justify-center transition-all duration-200 cursor-pointer',
+              'relative z-10 w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200 cursor-pointer active:scale-[0.92] motion-safe:transition-transform',
               isActive
-                ? 'bg-brand-subtle text-brand'
+                ? 'text-brand'
                 : 'text-text-muted hover:text-text-secondary hover:bg-bg-subtle',
             )}
             aria-label={item.label}
+            aria-pressed={isActive}
           >
             <Icon size={17} strokeWidth={1.6} />
             {badge > 0 && (
               <span
                 className={cn(
-                  'absolute -top-0.5 -right-0.5 min-w-[16px] h-[16px] px-1 rounded-full flex items-center justify-center text-[9.5px] font-semibold tabular-nums',
+                  'absolute -top-0.5 -right-0.5 min-w-[16px] h-[16px] px-1 rounded-full flex items-center justify-center text-[9.5px] font-semibold tabular-nums transition-colors',
                   isActive ? 'bg-brand text-white' : 'bg-text-primary text-bg-surface',
                 )}
               >
@@ -86,6 +98,7 @@ function OverlayFallback() {
 
 export default function App() {
   const [overlay, setOverlay] = useState<Overlay>(null);
+  const [overlayClosing, setOverlayClosing] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const storedOnboarded = useLocalStorage('seoul-ai-guide-onboarded');
   const [onboardedOverride, setOnboardedOverride] = useState(false);
@@ -111,11 +124,31 @@ export default function App() {
 
   const openSidebar = useCallback(() => setSidebarOpen(true), []);
   const closeSidebar = useCallback(() => setSidebarOpen(false), []);
-  const closeOverlay = useCallback(() => setOverlay(null), []);
-  const goHome = useCallback(() => {
-    setOverlay(null);
-    setSidebarOpen(false);
+  // 오버레이 닫기 — 200ms exit 애니메이션 후 unmount.
+  const closeOverlay = useCallback(() => {
+    setOverlayClosing(true);
+    window.setTimeout(() => {
+      setOverlay(null);
+      setOverlayClosing(false);
+    }, 200);
   }, []);
+  const goHome = useCallback(() => {
+    closeOverlay();
+    setSidebarOpen(false);
+  }, [closeOverlay]);
+
+  // NavButtons에서 다른 overlay로 이동할 때는 즉시 교체 (애니메이션 없이).
+  const selectOverlay = useCallback(
+    (key: Overlay) => {
+      if (key === null) {
+        closeOverlay();
+      } else {
+        setOverlayClosing(false);
+        setOverlay(key);
+      }
+    },
+    [closeOverlay],
+  );
 
   if (!onboarded) {
     return (
@@ -130,7 +163,7 @@ export default function App() {
       <div className="h-full flex flex-col bg-bg-base">
         <header className="flex items-center justify-between px-3 h-[52px] shrink-0 border-b border-border bg-bg-surface/90 backdrop-blur-md z-20">
           <ChatHeader onOpenSidebar={openSidebar} onGoHome={goHome} />
-          <NavButtons overlay={overlay} onSelect={setOverlay} bookmarkCount={totalBookmarks} />
+          <NavButtons overlay={overlay} onSelect={selectOverlay} bookmarkCount={totalBookmarks} />
         </header>
 
         <ChatMessages />
@@ -139,7 +172,14 @@ export default function App() {
         <ChatSidebar isOpen={sidebarOpen} onClose={closeSidebar} />
 
         {overlay && (
-          <div className="fixed inset-0 z-30 bg-bg-base flex flex-col" style={{ animation: 'overlayIn 0.25s cubic-bezier(0.32, 0.72, 0, 1)' }}>
+          <div
+            className="fixed inset-0 z-30 bg-bg-base flex flex-col"
+            style={{
+              animation: overlayClosing
+                ? 'overlayOut 0.2s cubic-bezier(0.32, 0.72, 0, 1) forwards'
+                : 'overlayIn 0.25s cubic-bezier(0.32, 0.72, 0, 1)',
+            }}
+          >
             <header className="flex items-center justify-between px-3 h-[52px] shrink-0 border-b border-border bg-bg-surface">
               <button
                 onClick={closeOverlay}

--- a/src/components/bookmark/BookmarkPanel.tsx
+++ b/src/components/bookmark/BookmarkPanel.tsx
@@ -33,13 +33,21 @@ export default function BookmarkPanel({ onClose }: Props) {
 
   return (
     <div className="h-full flex flex-col bg-bg-base">
-      {/* Segmented tabs */}
+      {/* Segmented tabs — 슬라이딩 pill 인디케이터 */}
       <div className="px-4 pt-4 pb-3 shrink-0">
         <div
           role="tablist"
           aria-label="북마크 종류"
           className="relative flex items-center gap-1 p-1 bg-bg-subtle rounded-full border border-border/60"
         >
+          {/* sliding pill — 활성 탭 인덱스(0/1)에 따라 50% 슬라이드 */}
+          <span
+            aria-hidden
+            className="pointer-events-none absolute top-1 bottom-1 left-1 w-[calc(50%-0.25rem)] rounded-full bg-bg-surface shadow-sm border border-border transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+            style={{
+              transform: tab === 'message' ? 'translateX(calc(100% + 0.25rem))' : 'translateX(0)',
+            }}
+          />
           <TabButton
             active={tab === 'place'}
             label="장소"
@@ -57,13 +65,15 @@ export default function BookmarkPanel({ onClose }: Props) {
         </div>
       </div>
 
-      {/* Content */}
+      {/* Content — 탭 변경 시 cross-fade */}
       <div className="flex-1 overflow-y-auto overscroll-contain">
-        {tab === 'place' ? (
-          <PlaceBookmarks places={places} onClose={onClose} />
-        ) : (
-          <MessageBookmarks items={messageItems} onClose={onClose} />
-        )}
+        <div key={tab} className="animate-tab-content">
+          {tab === 'place' ? (
+            <PlaceBookmarks places={places} onClose={onClose} />
+          ) : (
+            <MessageBookmarks items={messageItems} onClose={onClose} />
+          )}
+        </div>
       </div>
     </div>
   );
@@ -78,10 +88,8 @@ function TabButton({
       aria-selected={active}
       onClick={onClick}
       className={cn(
-        'flex-1 flex items-center justify-center gap-1.5 h-9 rounded-full text-[13px] font-medium transition-all duration-200 cursor-pointer',
-        active
-          ? 'bg-bg-surface text-text-primary shadow-sm border border-border'
-          : 'text-text-muted hover:text-text-secondary',
+        'relative z-10 flex-1 flex items-center justify-center gap-1.5 h-9 rounded-full text-[13px] font-medium transition-colors duration-200 cursor-pointer active:scale-[0.97] motion-safe:transition-transform',
+        active ? 'text-text-primary' : 'text-text-muted hover:text-text-secondary',
       )}
     >
       {icon}

--- a/src/globals.css
+++ b/src/globals.css
@@ -124,6 +124,16 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+@keyframes overlayOut {
+  from { opacity: 1; transform: translateY(0); }
+  to { opacity: 0; transform: translateY(12px); }
+}
+
+@keyframes tabContentIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 @keyframes compactBreathe {
   0%, 100% { transform: scale(1); }
   50% { transform: scale(1.04); }
@@ -169,6 +179,7 @@
 .animate-slide-up { animation: slide-up 0.3s cubic-bezier(0.32, 0.72, 0, 1); }
 
 .animate-message { animation: messageIn 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; }
+.animate-tab-content { animation: tabContentIn 0.22s cubic-bezier(0.32, 0.72, 0, 1) both; }
 .animate-fade-up { animation: fadeUp 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; }
 .animate-scale-in { animation: scaleIn 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards; }
 


### PR DESCRIPTION
## Summary
탭 전환과 오버레이 진입/이탈에 트렌디한 마이크로 인터랙션 추가.

## 변경
- **헤더 NavButtons** (북마크/지도/일정): 활성 인디케이터가 부드럽게 슬라이드 (Linear/Vercel 스타일)
  - 인덱스 기반 \`translateX\` (\`activeIndex * 38px\`), 300ms \`cubic-bezier(0.32,0.72,0,1)\`
  - 비활성 → 활성 전환 시 인디케이터가 슬라이드, 동시에 색상 페이드
  - 클릭 micro-press: \`active:scale-[0.92]\`
- **BookmarkPanel segmented** (장소/대화): 슬라이딩 pill로 교체
  - 50% 너비 absolute pill이 \`translateX(0|100%)\`로 이동
  - 탭 콘텐츠 \`key={tab}\` + \`animate-tab-content\` (4px 위로 슬라이드 + fade-in)
- **오버레이 exit 애니메이션**: 닫기 시 \`overlayOut\` 키프레임 (translateY 12px + fade-out, 200ms) 후 unmount
  - 다른 오버레이로 전환 시엔 즉시 교체 (closing 스킵) — \`selectOverlay\` 헬퍼

## 검수
1. 헤더 우상단 북마크 → 지도 → 일정 클릭 — 활성 표시가 슬라이드
2. 북마크 패널 진입 → 장소/대화 탭 전환 — pill 슬라이드 + 콘텐츠 cross-fade
3. 오버레이 "닫기" 또는 햄버거 메뉴 진입 — fade-out 후 사라짐
4. \`prefers-reduced-motion\` 설정 시 \`motion-safe:transition-transform\`로 micro-press 비활성

🤖 Generated with [Claude Code](https://claude.com/claude-code)