### PR TITLE
fix: 코스 경로 보기가 클릭한 코스의 stops를 따르도록

### DIFF
--- a/src/components/map/ThreeMap.tsx
+++ b/src/components/map/ThreeMap.tsx
@@ -135,10 +135,12 @@ export default function ThreeMap({
       return;
     }
 
-    // Build stop coords from markers
+    // Build stop coords from markers, fallback to stop's own lat/lng (SSE-driven).
     const stopCoords = navigation.itinerary.stops.map((stop) => {
       const place = markers.find((m) => m.id === stop.placeId);
-      return place ? { lat: place.lat, lng: place.lng } : null;
+      if (place) return { lat: place.lat, lng: place.lng };
+      if (stop.lat != null && stop.lng != null) return { lat: stop.lat, lng: stop.lng };
+      return null;
     }).filter((c): c is { lat: number; lng: number } => c !== null);
 
     if (stopCoords.length < 2) return;

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -42,8 +42,12 @@ function courseBlockToItinerary(block: CourseBlock): Itinerary {
     const arrivalTime = `${hh}:${mm}`;
     const duration = s.duration_minutes ?? 60;
     cursor += duration + 15; // 다음 정거장까지 도보 15분 가정
-    // image_url은 BE 표준 CourseStop엔 없는 mock 확장 필드. 있으면 통과.
-    const ext = s as typeof s & { image_url?: string };
+    // image_url, address, category는 BE 표준 CourseStop엔 없는 mock 확장 필드.
+    const ext = s as typeof s & {
+      image_url?: string;
+      address?: string;
+      category?: PlaceCategory;
+    };
     return {
       order: s.order ?? i + 1,
       placeId: s.place_id,
@@ -52,7 +56,11 @@ function courseBlockToItinerary(block: CourseBlock): Itinerary {
       duration,
       transportToNext: 'walk' as TransportMode,
       travelTimeToNext: i < block.stops.length - 1 ? 15 : 0,
+      lat: s.lat,
+      lng: s.lng,
       imageUrl: ext.image_url,
+      address: ext.address,
+      category: ext.category,
     };
   });
   return {

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -36,9 +36,27 @@ interface MapStore {
 const SEOUL_CENTER = { lat: 37.5665, lng: 126.978 };
 
 function getPlacesForItinerary(itinerary: Itinerary): Place[] {
+  // 1순위: places.json 매칭 (레거시 mock 일정).
+  // 2순위: SSE-driven 일정 — stop 자체 필드(lat/lng/imageUrl 등)로 Place 합성.
   return itinerary.stops
-    .map((stop) => allPlaces.find((p) => p.id === stop.placeId))
-    .filter((p): p is Place => p !== undefined);
+    .map((stop): Place | null => {
+      const matched = allPlaces.find((p) => p.id === stop.placeId);
+      if (matched) return matched;
+      if (stop.lat == null || stop.lng == null) return null;
+      return {
+        id: stop.placeId,
+        name: stop.placeName,
+        category: stop.category ?? 'tourism',
+        address: stop.address ?? '',
+        lat: stop.lat,
+        lng: stop.lng,
+        hours: '',
+        rating: 0,
+        summary: '',
+        image: stop.imageUrl,
+      };
+    })
+    .filter((p): p is Place => p !== null);
 }
 
 export const useMapStore = create<MapStore>((set, get) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,8 +38,12 @@ export interface ItineraryStop {
   duration: number; // minutes
   transportToNext: TransportMode;
   travelTimeToNext: number; // minutes
-  // SSE 어댑터로부터 직접 받은 이미지 (places.json에 없는 SSE-driven 코스용 폴백).
+  // SSE 어댑터로부터 직접 받은 필드 (places.json 매칭 안 되는 SSE-driven 코스용).
+  lat?: number;
+  lng?: number;
   imageUrl?: string;
+  address?: string;
+  category?: PlaceCategory;
 }
 
 export interface Itinerary {


### PR DESCRIPTION
## 문제
SSE-driven course의 \`placeId\`(예: 'h1', 's1')는 \`places.json\`(place-001~008)에 없음 → \`mapStore.getPlacesForItinerary\`가 빈 배열 반환 → ThreeMap 폴백 없어서 잘못된 마커/경로 노출. 5번째 (명동) 코스를 눌러도 첫 번째(종로) stops가 보이거나 빈 지도.

## 변경
- **ItineraryStop**에 \`lat\`, \`lng\`, \`imageUrl\`, \`address\`, \`category\` 옵셔널 필드 추가
- **chatStore courseBlockToItinerary**: SSE CourseStop의 좌표/메타를 통과
- **mapStore.getPlacesForItinerary**: \`places.json\` 매칭 실패 시 stop 자체 필드로 Place 합성
- **ThreeMap stopCoords**: marker lookup 실패 시 \`stop.lat/lng\` 폴백

## 검수
1. "코스 짜줘" → 5장 카드
2. 각 카드의 "경로 보기" 클릭 → 그 코스의 stops가 마커 + 폴리라인으로 정확히 렌더
   - 종로 → 광장시장/경복궁/북촌
   - 성수 → 어니언/대림창고/서울숲
   - 명동 → 명동거리/명동교자/N서울타워

🤖 Generated with [Claude Code](https://claude.com/claude-code)