### PR TITLE
fix: 장소 북마크가 SSE-driven 장소도 보존하도록 — placeSnapshots

### DIFF
--- a/src/components/bookmark/BookmarkPanel.tsx
+++ b/src/components/bookmark/BookmarkPanel.tsx
@@ -20,13 +20,14 @@ export default function BookmarkPanel({ onClose }: Props) {
   const [tab, setTab] = useState<Tab>('place');
 
   const bookmarkedIds = useBookmarkStore((s) => s.bookmarkedIds);
+  const placeSnapshots = useBookmarkStore((s) => s.placeSnapshots);
   const messageItems = useBookmarkStore((s) => s.messageItems);
   const places = useMemo(
     () =>
       bookmarkedIds
-        .map((id) => ALL_PLACES.find((p) => p.id === id))
+        .map((id) => placeSnapshots[id] ?? ALL_PLACES.find((p) => p.id === id))
         .filter((p): p is Place => p !== undefined),
-    [bookmarkedIds],
+    [bookmarkedIds, placeSnapshots],
   );
 
   const counts = { place: places.length, message: messageItems.length };

--- a/src/components/chat/PlaceCard.tsx
+++ b/src/components/chat/PlaceCard.tsx
@@ -25,7 +25,7 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
 
   const handleBookmark = (e: React.MouseEvent) => {
     e.stopPropagation();
-    toggleBookmark(place.id);
+    toggleBookmark(place);
   };
 
   return (

--- a/src/components/chat/PlaceCarousel.tsx
+++ b/src/components/chat/PlaceCarousel.tsx
@@ -25,8 +25,8 @@ function PlaceCardTile({ place, variant, onSelect }: PlaceCardTileProps) {
 
   const handleBookmark = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation();
-    toggleBookmark(place.id);
-  }, [place.id, toggleBookmark]);
+    toggleBookmark(place);
+  }, [place, toggleBookmark]);
 
   const widthClass = variant === 'single' ? 'w-full max-w-[350px]' : 'flex-none w-[280px]';
 

--- a/src/components/map/PlaceOverlayItem.tsx
+++ b/src/components/map/PlaceOverlayItem.tsx
@@ -25,8 +25,8 @@ export default memo(function PlaceOverlayItem({ place, isBookmark, isSelected, o
 
   const handleBookmark = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
-    toggleBookmark(place.id);
-  }, [place.id, toggleBookmark]);
+    toggleBookmark(place);
+  }, [place, toggleBookmark]);
 
   return (
     <div

--- a/src/stores/bookmarkStore.ts
+++ b/src/stores/bookmarkStore.ts
@@ -5,6 +5,7 @@ import placesData from '@/mocks/places.json';
 const allPlaces = placesData as Place[];
 
 const PLACE_STORAGE_KEY = 'seoul-ai-bookmarks';
+const PLACE_SNAPSHOT_STORAGE_KEY = 'seoul-ai-bookmark-snapshots';
 const MSG_STORAGE_KEY = 'seoul-ai-message-bookmarks';
 const DEFAULT_PLACE_IDS = ['place-001', 'place-002', 'place-003', 'place-004'];
 
@@ -17,6 +18,24 @@ function loadPlaceIds(): string[] {
   } catch {
     return DEFAULT_PLACE_IDS;
   }
+}
+
+function loadPlaceSnapshots(): Record<string, Place> {
+  try {
+    const raw = localStorage.getItem(PLACE_SNAPSHOT_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object') return parsed as Record<string, Place>;
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function savePlaceSnapshots(snapshots: Record<string, Place>) {
+  try {
+    localStorage.setItem(PLACE_SNAPSHOT_STORAGE_KEY, JSON.stringify(snapshots));
+  } catch { /* ignore */ }
 }
 
 function loadMessageItems(): MessageBookmarkItem[] {
@@ -49,9 +68,12 @@ interface ToggleMessageInput {
 }
 
 interface BookmarkStore {
-  // Place bookmarks (existing API, preserved)
+  // Place bookmarks
   bookmarkedIds: string[];
-  toggle: (id: string) => void;
+  // SSE-driven 장소(places.json에 없는)도 카드에 노출되도록 스냅샷 보관.
+  placeSnapshots: Record<string, Place>;
+  // toggle에 Place를 넘기면 스냅샷 같이 저장 (권장). string 단독 호출은 레거시 호환.
+  toggle: (input: string | Place) => void;
   add: (id: string) => void;
   remove: (id: string) => void;
   isBookmarked: (id: string) => boolean;
@@ -66,15 +88,26 @@ interface BookmarkStore {
 
 export const useBookmarkStore = create<BookmarkStore>((set, get) => ({
   bookmarkedIds: typeof window !== 'undefined' ? loadPlaceIds() : DEFAULT_PLACE_IDS,
+  placeSnapshots: typeof window !== 'undefined' ? loadPlaceSnapshots() : {},
   messageItems: typeof window !== 'undefined' ? loadMessageItems() : [],
 
-  toggle: (id) => {
-    const { bookmarkedIds } = get();
-    const next = bookmarkedIds.includes(id)
-      ? bookmarkedIds.filter((x) => x !== id)
-      : [...bookmarkedIds, id];
-    savePlaceIds(next);
-    set({ bookmarkedIds: next });
+  toggle: (input) => {
+    const place = typeof input === 'string' ? null : input;
+    const id = place ? place.id : input as string;
+    const { bookmarkedIds, placeSnapshots } = get();
+    const isAdded = !bookmarkedIds.includes(id);
+    const nextIds = isAdded
+      ? [...bookmarkedIds, id]
+      : bookmarkedIds.filter((x) => x !== id);
+    const nextSnapshots = { ...placeSnapshots };
+    if (isAdded && place) {
+      nextSnapshots[id] = place;
+    } else if (!isAdded) {
+      delete nextSnapshots[id];
+    }
+    savePlaceIds(nextIds);
+    savePlaceSnapshots(nextSnapshots);
+    set({ bookmarkedIds: nextIds, placeSnapshots: nextSnapshots });
   },
 
   add: (id) => {
@@ -86,17 +119,23 @@ export const useBookmarkStore = create<BookmarkStore>((set, get) => ({
   },
 
   remove: (id) => {
-    const next = get().bookmarkedIds.filter((x) => x !== id);
+    const { bookmarkedIds, placeSnapshots } = get();
+    const next = bookmarkedIds.filter((x) => x !== id);
+    const nextSnapshots = { ...placeSnapshots };
+    delete nextSnapshots[id];
     savePlaceIds(next);
-    set({ bookmarkedIds: next });
+    savePlaceSnapshots(nextSnapshots);
+    set({ bookmarkedIds: next, placeSnapshots: nextSnapshots });
   },
 
   isBookmarked: (id) => get().bookmarkedIds.includes(id),
 
-  getBookmarkedPlaces: () =>
-    get()
-      .bookmarkedIds.map((id) => allPlaces.find((p) => p.id === id))
-      .filter((p): p is Place => p !== undefined),
+  getBookmarkedPlaces: () => {
+    const { bookmarkedIds, placeSnapshots } = get();
+    return bookmarkedIds
+      .map((id) => placeSnapshots[id] ?? allPlaces.find((p) => p.id === id))
+      .filter((p): p is Place => p !== undefined);
+  },
 
   toggleMessage: ({ messageId, conversationId, snapshot }) => {
     const { messageItems } = get();


### PR DESCRIPTION
## 문제
\`bookmarkStore.toggle(id)\`가 ID만 저장. \`PlaceBookmarks\`는 \`places.json\`에서 lookup하는데, SSE-driven 장소(예: h1=앤트러사이트)는 \`places.json\`에 없어서 북마크 패널에 표시 안 됨 → 사실상 북마크 안 됨.

## 변경
- \`bookmarkStore\`에 \`placeSnapshots: Record<string, Place>\` 추가, 별도 localStorage 키로 영속
- \`toggle(input: string | Place)\` — Place로 호출 시 스냅샷 같이 저장 (string 호출은 레거시 호환)
- 토글 호출 사이트 모두 Place 객체 전달:
  - PlaceCard
  - PlaceCarousel.PlaceCardTile
  - PlaceOverlayItem
- BookmarkPanel.PlaceBookmarks: snapshots 우선, places.json 폴백

## 검수
1. "홍대 카페" → 카드 별표 클릭 → 우상단 북마크 탭 → 장소 탭 → **앤트러사이트 홍대** 카드 노출 (이미지/이름/주소 정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)