### PR TITLE
fix: 카드 클릭 → 지도 자동 오픈 + 북마크 stale ID 정리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,12 @@ export default function App() {
     if (navigation) setOverlay('map');
   }, [navigation]);
 
+  // 카드 클릭(selectPlace) 시 지도 오버레이 자동 오픈.
+  const selectedPlace = useMapStore((s) => s.selectedPlace);
+  useEffect(() => {
+    if (selectedPlace) setOverlay('map');
+  }, [selectedPlace]);
+
   const handleOnboardingComplete = useCallback(() => {
     try { localStorage.setItem('seoul-ai-guide-onboarded', 'true'); } catch { /* ignore */ }
     setOnboardedOverride(true);

--- a/src/components/chat/PlaceCard.tsx
+++ b/src/components/chat/PlaceCard.tsx
@@ -32,7 +32,11 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
     <>
       <article
         aria-label={`${place.name} - ${cat.label}`}
-        className="group bg-bg-surface border border-border rounded-2xl overflow-hidden transition-[border-color,box-shadow,transform] duration-200 hover:shadow-md hover:border-border-strong hover:-translate-y-[1px]"
+        onClick={handleViewOnMap}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleViewOnMap(); }}
+        role="button"
+        tabIndex={0}
+        className="group bg-bg-surface border border-border rounded-2xl overflow-hidden transition-[border-color,box-shadow,transform] duration-200 hover:shadow-md hover:border-border-strong hover:-translate-y-[1px] cursor-pointer"
       >
         <div className="relative aspect-video bg-bg-subtle overflow-hidden">
           {place.image && (

--- a/src/stores/bookmarkStore.ts
+++ b/src/stores/bookmarkStore.ts
@@ -86,8 +86,17 @@ interface BookmarkStore {
   isMessageBookmarked: (messageId: string) => boolean;
 }
 
+// 초기 ID 중 places.json에도 없고 snapshots에도 없으면 stale → 제거.
+// (이전 버전에서 SSE 장소 ID만 저장된 경우 해당)
+function purgeStaleIds(ids: string[], snapshots: Record<string, Place>): string[] {
+  return ids.filter((id) => snapshots[id] || allPlaces.some((p) => p.id === id));
+}
+
 export const useBookmarkStore = create<BookmarkStore>((set, get) => ({
-  bookmarkedIds: typeof window !== 'undefined' ? loadPlaceIds() : DEFAULT_PLACE_IDS,
+  bookmarkedIds:
+    typeof window !== 'undefined'
+      ? purgeStaleIds(loadPlaceIds(), loadPlaceSnapshots())
+      : DEFAULT_PLACE_IDS,
   placeSnapshots: typeof window !== 'undefined' ? loadPlaceSnapshots() : {},
   messageItems: typeof window !== 'undefined' ? loadMessageItems() : [],
 

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -74,7 +74,12 @@ export const useMapStore = create<MapStore>((set, get) => ({
 
   setRoute: (route) => set({ route }),
 
-  selectPlace: (place) => set({ selectedPlace: place }),
+  selectPlace: (place) =>
+    set({
+      selectedPlace: place,
+      // 카드 클릭 시 지도 중심을 해당 장소로 이동.
+      mapCenter: place ? { lat: place.lat, lng: place.lng } : SEOUL_CENTER,
+    }),
 
   clearMap: () => set({ markers: [], route: [], selectedPlace: null, mapCenter: SEOUL_CENTER }),
 


### PR DESCRIPTION
## 변경 1 — 카드 클릭 시 지도 자동 오픈
- \`mapStore.selectPlace\`가 \`mapCenter\`도 같이 이동
- \`PlaceCard\` 전체 영역에 \`onClick\` → \`selectPlace(place)\`
- \`App.tsx\`: \`selectedPlace\` 변경 시 \`'map'\` 오버레이 오픈

## 변경 2 — 북마크 stale ID 정리
이전 버전에서 SSE 장소 ID만 저장된 경우(snapshot 없음) 패널에서 안 보이던 문제. 부팅 시 \`places.json\`에도 없고 \`snapshots\`에도 없는 ID는 자동 제거 → 새로 별표 클릭 시 정상 저장.

## 검수
1. 채팅 카드 (어디든) 클릭 → 지도 오버레이 자동 오픈, 그 위치로 카메라 이동
2. 카드 별표 → 북마크 탭 → 장소 탭에 즉시 노출 (이미지 포함)
3. 새로고침 후에도 유지됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)