### PR TITLE
fix: 장소 북마크 카드 클릭 → 지도 오버레이 전환

### DIFF
--- a/src/components/bookmark/BookmarkPanel.tsx
+++ b/src/components/bookmark/BookmarkPanel.tsx
@@ -134,7 +134,7 @@ function PlaceBookmarks({ places, onClose }: { places: Place[]; onClose?: () => 
           <article
             key={place.id}
             className="group flex items-center gap-3 p-2 bg-bg-surface border border-border rounded-2xl transition-all duration-200 hover:border-border-strong hover:shadow-sm cursor-pointer"
-            onClick={() => { selectPlace(place); onClose?.(); }}
+            onClick={() => { selectPlace(place); }}
           >
             <div
               className="relative w-[68px] h-[68px] rounded-xl bg-bg-subtle shrink-0 overflow-hidden flex items-center justify-center"


### PR DESCRIPTION
## 문제
PlaceBookmarks 카드 클릭이 \`selectPlace\` + \`onClose\` 동시 호출:
- \`selectPlace\` → \`useEffect\`에서 \`setOverlay('map')\`
- \`onClose\` → \`closeOverlay\` → 200ms 후 \`setOverlay(null)\`

두 set 호출이 경합 → 사용자에게는 잠깐 지도 떴다 사라지고 채팅 화면이 보임 ("대화가 불러와진다"는 인상).

## 변경
\`onClose()\` 제거. \`selectPlace\`만 호출 → \`useEffect\`가 자연스럽게 overlay 'bookmark' → 'map' 교체. 같은 오버레이 div가 콘텐츠만 swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)