### PR TITLE
feat(api-integration): Phase 1 — BE 연동 인프라 + 인증 흐름

### DIFF
--- a/docs/exec-plans/active/api-integration/phase-1-auth.md
+++ b/docs/exec-plans/active/api-integration/phase-1-auth.md
@@ -1,0 +1,86 @@
+# Phase 1 — 인증 + 401 흐름
+
+**브랜치**: `feat/api-integration`
+**BE**: `http://34.22.91.75:8000` (GCE `localbiz-api`, AnyWay v0.1.0)
+**dev 접근**: vite proxy(same-origin) → BE. CORS 우회.
+
+---
+
+## 결정사항
+
+### 1. dev BE 접속은 vite proxy로 처리
+- 이유: BE의 CORS allow-origin이 `http://localhost:5173` 한 곳만이라 포트가 바뀌면 깨짐
+- `vite.config.ts > server.proxy`에서 `/api`, `/health`, `/shared`를 dev BE로 전달
+- `.env.local`의 `VITE_API_BASE`는 빈 값 유지(same-origin)
+- BE 대상 변경은 `VITE_DEV_BE` 환경변수로 (vite.config.ts 참조)
+
+### 2. Pydantic 422 응답을 한글로 변환
+- BE는 422 응답을 `{"detail": [{loc, msg, type, ...}, ...]}` 배열로 반환
+- 기존 `extractErrorMessage`는 array 케이스를 못 잡아서 `HTTP 422`로 폴백 → 사용자에게 무의미
+- `humanizePydanticMsg` 헬퍼로 자주 보이는 영문 msg 4종을 한글로 매핑
+
+### 3. status별 사용자 메시지 정규화
+- `lib/auth-errors.ts > friendlyAuthError`가 LoginPage/SignupPage 공유
+- BE 응답이 한글이면 그대로(401), 영문/구조적이면 한글 폴백(409 중복, 422, 5xx)
+
+### 4. Google OAuth FE 주석 정리
+- BE는 `POST /api/v1/auth/google` 라우트 노출 중. `api.ts`의 "BE 미구현" 주석 제거
+- 실제 UI 활성화(소셜 버튼)는 Phase 4로 미룸
+
+---
+
+## 변경된 파일
+
+| 파일 | 변경 |
+|---|---|
+| `vite.config.ts` | `server.proxy` 추가 (`/api`, `/health`, `/shared`) |
+| `.env.local` | `VITE_API_BASE`를 빈 값으로 (proxy 사용), BE 참조 주석 정리 |
+| `src/types/api.ts` | `ApiErrorDetailItem` 신설, `ApiError.detail`에 array 케이스 추가 |
+| `src/lib/api.ts` | `humanizePydanticMsg` + `extractErrorMessage` 배열 처리, google 주석 정리 |
+| `src/lib/auth-errors.ts` | 신규 — `friendlyAuthError(err, mode)` 헬퍼 |
+| `src/components/auth/LoginPage.tsx` | catch 블록에서 `friendlyAuthError` 사용 |
+| `src/components/auth/SignupPage.tsx` | catch 블록에서 `friendlyAuthError` 사용 |
+
+---
+
+## BE 응답 패턴 정찰 결과
+
+| 시나리오 | HTTP | body | 처리 |
+|---|---|---|---|
+| 회원가입 정상 | 201 | `TokenResponse` JSON | 기존 흐름 OK |
+| 이메일 중복 | 409 | `{"detail":"email already exists"}` (영문) | `friendlyAuthError` → "이미 가입된 이메일입니다" |
+| 로그인 실패 | 401 | `{"detail":"이메일 또는 비밀번호가 올바르지 않습니다"}` (한글) | 그대로 노출 |
+| 짧은 비번 로그인 | 401 | (한글) | 그대로 노출 |
+| 이메일 형식 위반 | 422 | Pydantic detail 배열 (영문 msg) | `humanizePydanticMsg`로 한글 변환 |
+| 필수 필드 누락 | 422 | Pydantic detail 배열 | 동일 |
+| 토큰 만료 / 위변조 | 401 | `{"detail":"유효하지 않은 인증"}` | `authStore.init`의 `setOnUnauthorized` → 토스트 + 로그아웃 |
+
+---
+
+## 검증 결과
+
+### 코드 레벨 (자동)
+- [x] `tsc --noEmit` 통과
+- [x] `vitest run` — 13/13 tests passed
+- [x] vite proxy via curl — `/health` 200, `/api/v1/chats` 401, `/api/v1/auth/login` 422 확인
+
+### 브라우저 레벨 (수동 — 미실행)
+다음 시나리오는 dev 서버 `http://localhost:5174`에서 사용자가 검증해야 함:
+- [ ] `/signup` 이메일 형식 위반 → `email: 이메일 형식이 올바르지 않습니다` 토스트
+- [ ] `/signup` 중복 이메일 → `이미 가입된 이메일입니다`
+- [ ] `/login` 잘못된 비번 → `이메일 또는 비밀번호가 올바르지 않습니다`
+- [ ] 정상 로그인 → 메인 화면 진입
+- [ ] localStorage 토큰 위변조 → 새로고침 시 토스트 + `/login` 리다이렉트
+
+테스트 계정 예시:
+- email: `claude_test_1778575930@example.com` / pw: `testpass1234` (Phase 1 정찰 중 생성)
+
+---
+
+## 다음 Phase
+
+- **Phase 2 — 채팅 스토어 교체** (가장 큰 변경)
+- `chatStore`(localStorage) → `apiChatStore`(BE) 스왑
+- 영향 컴포넌트 8개:
+  `App`, `ChatHeader`, `ChatMessages`, `ChatInputConnected`, `ChatSidebar`, `MessageBubble`, `StreamingMessage`, `BookmarkPanel`
+- 검증 대상: SSE `/api/v1/chat/stream`, 메시지 페이징, optimistic send, 빈/로딩/에러 상태

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+import { friendlyAuthError } from '@/lib/auth-errors';
 import AuthLayout from './AuthLayout';
 import Button from '@/components/ui/Button';
 
@@ -29,7 +30,7 @@ export default function LoginPage() {
       await login(email.trim(), password);
       navigate(from, { replace: true });
     } catch (err) {
-      setError((err as Error).message || '로그인에 실패했습니다');
+      setError(friendlyAuthError(err, 'login'));
     } finally {
       setSubmitting(false);
     }

--- a/src/components/auth/SignupPage.tsx
+++ b/src/components/auth/SignupPage.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
+import { friendlyAuthError } from '@/lib/auth-errors';
 import AuthLayout from './AuthLayout';
 import Button from '@/components/ui/Button';
 
@@ -21,7 +22,7 @@ export default function SignupPage() {
       await signup(email.trim(), password, nickname.trim() || undefined);
       navigate('/', { replace: true });
     } catch (err) {
-      setError((err as Error).message || '회원가입에 실패했습니다');
+      setError(friendlyAuthError(err, 'signup'));
     } finally {
       setSubmitting(false);
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -89,9 +89,32 @@ export class ApiHttpError extends Error {
   }
 }
 
+// Pydantic의 영문 msg 일부를 사용자 화면용 한글로 치환. 매핑 없는 경우 원문 유지.
+function humanizePydanticMsg(msg: string | undefined): string {
+  if (!msg) return '';
+  if (msg.startsWith('Field required')) return '필수 입력 항목입니다';
+  if (msg.includes('valid email address')) return '이메일 형식이 올바르지 않습니다';
+  const minMatch = msg.match(/at least (\d+) character/i);
+  if (minMatch) return `최소 ${minMatch[1]}자 이상이어야 합니다`;
+  const maxMatch = msg.match(/at most (\d+) character/i);
+  if (maxMatch) return `최대 ${maxMatch[1]}자까지 가능합니다`;
+  return msg;
+}
+
 function extractErrorMessage(payload: ApiError | undefined, status: number): { code?: string; message: string } {
   if (!payload) return { message: `HTTP ${status}` };
   if (typeof payload.detail === 'string') return { message: payload.detail };
+  // FastAPI 422 — Pydantic ValidationError가 detail 배열로 들어옴.
+  if (Array.isArray(payload.detail)) {
+    const lines = payload.detail
+      .map((d) => {
+        const field = Array.isArray(d.loc) && d.loc.length > 0 ? String(d.loc[d.loc.length - 1]) : '';
+        const human = humanizePydanticMsg(d.msg);
+        return field ? `${field}: ${human}` : human;
+      })
+      .filter(Boolean);
+    return { message: lines.length > 0 ? lines.join(', ') : `HTTP ${status}` };
+  }
   if (payload.detail && typeof payload.detail === 'object') {
     return { code: payload.detail.code, message: payload.detail.message ?? `HTTP ${status}` };
   }
@@ -200,8 +223,6 @@ export const authApi = {
     request<TokenResponse>('/api/v1/auth/signup', { method: 'POST', body: JSON.stringify(body), auth: false }),
   login: (body: { email: string; password: string }) =>
     request<TokenResponse>('/api/v1/auth/login', { method: 'POST', body: JSON.stringify(body), auth: false }),
-  // ⚠️ BE 미구현 (`models/user.py`에 GoogleLoginRequest는 있으나 라우트 추가 대기 중).
-  //   호출 시 404. BE 라우트 머지 후 활성화.
   google: (body: { id_token: string }) =>
     request<TokenResponse>('/api/v1/auth/google', { method: 'POST', body: JSON.stringify(body), auth: false }),
 };

--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -1,0 +1,24 @@
+import { ApiHttpError } from '@/lib/api';
+
+// Login/Signup 양 페이지가 공유하는 에러 메시지 매핑.
+// BE 응답이 영문이거나 HTTP status로만 의미가 드러나는 케이스를 한글 폴백으로 정규화.
+export function friendlyAuthError(err: unknown, mode: 'login' | 'signup'): string {
+  if (err instanceof ApiHttpError) {
+    if (err.status === 409) return '이미 가입된 이메일입니다';
+    if (err.status === 401) {
+      // BE가 이미 한글로 응답 (예: "이메일 또는 비밀번호가 올바르지 않습니다") — 그대로 사용.
+      return err.message || '이메일 또는 비밀번호가 올바르지 않습니다';
+    }
+    if (err.status === 422) {
+      // extractErrorMessage가 Pydantic 배열을 한글로 변환해 message에 담아둠.
+      return err.message || '입력값을 확인해 주세요';
+    }
+    if (err.status >= 500) return '서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요';
+    if (err.status === 0 || err.message === 'Timeout') return '네트워크 연결을 확인해 주세요';
+    if (err.message) return err.message;
+  }
+  return (
+    (err as Error)?.message ||
+    (mode === 'login' ? '로그인에 실패했습니다' : '회원가입에 실패했습니다')
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,14 +9,37 @@ import Toaster from '@/components/ui/Toaster';
 
 // MSW — dev 환경에서 BE 미배포 상태 검수용.
 // VITE_DISABLE_MSW=true 로 끌 수 있음 (실서버 붙일 때).
+//
+// ⚠️ 주의: 한 번 worker.start()가 호출되면 mockServiceWorker.js가 브라우저에
+//   service worker로 등록되고, 이후 새로고침에도 살아남아 fetch를 가로챈다.
+//   따라서 disable 모드에선 단순 early-return으로 부족하고, 기존에 등록된
+//   SW를 명시 unregister해 줘야 한다.
 async function startMockServiceWorker(): Promise<void> {
   if (!import.meta.env.DEV) return;
-  if (import.meta.env.VITE_DISABLE_MSW === 'true') return;
+  if (import.meta.env.VITE_DISABLE_MSW === 'true') {
+    await unregisterMswServiceWorker();
+    return;
+  }
   const { worker } = await import('@/mocks/msw/browser');
   await worker.start({
     onUnhandledRequest: 'bypass',
     serviceWorker: { url: '/mockServiceWorker.js' },
   });
+}
+
+async function unregisterMswServiceWorker(): Promise<void> {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
+  try {
+    const regs = await navigator.serviceWorker.getRegistrations();
+    for (const reg of regs) {
+      const url = reg.active?.scriptURL ?? '';
+      if (url.includes('mockServiceWorker')) {
+        await reg.unregister();
+      }
+    }
+  } catch {
+    // SW API 거부 환경 — 무시. 사용자가 DevTools에서 수동 해제 가능.
+  }
 }
 
 const LoginPage = lazy(() => import('@/components/auth/LoginPage'));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -303,7 +303,16 @@ export type SseEventType =
   | 'done_partial'
   | 'error';
 
+export type ApiErrorDetailItem = {
+  type?: string;
+  loc?: (string | number)[];
+  msg?: string;
+  input?: unknown;
+  ctx?: Record<string, unknown>;
+};
+
 export type ApiError = {
   error?: { code?: string; message?: string };
-  detail?: string | { code?: string; message?: string };
+  // FastAPI/Pydantic: 422 응답은 detail이 배열 형태. 그 외 라우트는 string/object.
+  detail?: string | { code?: string; message?: string } | ApiErrorDetailItem[];
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,23 @@ export default defineConfig({
     ],
   },
   server: {
+    // BE 연동 — same-origin proxy로 CORS 우회. VITE_API_BASE를 비워두면
+    // FE는 localhost:포트/api/v1/... 를 호출하고, vite가 dev BE로 전달한다.
+    // VITE_DEV_BE 환경변수로 타겟 변경 가능. 기본은 GCE localbiz-api.
+    proxy: {
+      '/api': {
+        target: process.env.VITE_DEV_BE || 'http://34.22.91.75:8000',
+        changeOrigin: true,
+      },
+      '/health': {
+        target: process.env.VITE_DEV_BE || 'http://34.22.91.75:8000',
+        changeOrigin: true,
+      },
+      '/shared': {
+        target: process.env.VITE_DEV_BE || 'http://34.22.91.75:8000',
+        changeOrigin: true,
+      },
+    },
     warmup: {
       clientFiles: [
         './src/App.tsx',


### PR DESCRIPTION
## Summary
- vite proxy(`/api`, `/health`, `/shared`)로 dev BE same-origin 처리 → CORS 우회
- Pydantic 422 배열 응답을 한글 메시지로 변환 (`humanizePydanticMsg`)
- 401/409/422/5xx status별 한글 폴백을 `friendlyAuthError`로 통일 (LoginPage/SignupPage)
- google OAuth 라우트 BE 존재 확인 → 주석 정리

## 변경 파일
- `vite.config.ts`, `src/lib/api.ts`, `src/lib/auth-errors.ts` (신규), `src/types/api.ts`
- `src/components/auth/{Login,Signup}Page.tsx`
- `docs/exec-plans/active/api-integration/phase-1-auth.md`

## Test plan
- [x] `pnpm tsc --noEmit` 통과
- [x] `pnpm test:run` — 13/13 tests
- [x] curl 검증: `/health` 200, `/api/v1/chats` 401(한글), `/api/v1/auth/login` 422
- [ ] (수동) `/login`에서 잘못된 비번 → "이메일 또는 비밀번호가 올바르지 않습니다"
- [ ] (수동) `/signup`에서 형식 위반 이메일 → 한글 안내

## Stacked PRs
이 PR 위에 Phase 2+3 / Phase 4 / Phase 5 PR이 차곡차곡 쌓입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)