### PR TITLE
feat(api-integration): Phase 4 — 공유/캘린더 + friendlyApiError 일반화

### DIFF
--- a/docs/exec-plans/active/api-integration/be-issue-bookmark-spec.md
+++ b/docs/exec-plans/active/api-integration/be-issue-bookmark-spec.md
@@ -1,0 +1,104 @@
+# [BE 이슈] 북마크 라우트 스펙 정합성
+
+**작성**: 2026-05-12, FE
+**환경**: GCE `localbiz-api` (`34.22.91.75:8000`), `AnyWay v0.1.0`
+**대상**: BE 북마크 API 담당자
+
+> 영속화 자체는 정상 작동합니다 (POST → 201 → 즉시 GET에 반영). 본 이슈는
+> **명세/타입 정합성**과 **DELETE 라우트의 307 redirect** 두 가지 마이너 사항입니다.
+
+---
+
+## 책임 라우트
+
+| 라우트 | 동작 | 비고 |
+|---|---|---|
+| `POST /api/v1/users/me/bookmarks` | ✅ 201 (integer message_id) | message_id 타입 명세 정정 필요 |
+| `GET /api/v1/users/me/bookmarks` | ✅ 200 | 정상 |
+| `DELETE /api/v1/users/me/bookmarks/{id}` | ⚠️ 307 redirect | trailing slash 차이로 보임 |
+
+---
+
+## 이슈 1: `message_id`는 integer만 받음 (스펙은 string 허용 표기)
+
+### 재현
+
+```bash
+# string으로 보내면 422
+curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"thread_id":"t1","message_id":"msg-1","pin_type":"general"}' \
+  http://34.22.91.75:8000/api/v1/users/me/bookmarks
+# →
+# {"detail":[{"type":"int_parsing","loc":["body","message_id"],
+#  "msg":"Input should be a valid integer, unable to parse string as an integer","input":"msg-1"}]}
+# [HTTP 422]
+
+# integer로 보내면 정상
+curl -X POST ... -d '{"thread_id":"t1","message_id":1,"pin_type":"general"}'
+# → 201
+```
+
+### 명세와의 차이
+
+- OpenAPI 응답의 `BookmarkItem.message_id`는 `{"type":"integer"}` 단독 — BE는 일관됨.
+- 그러나 **프로젝트 가이드 문서**(`apispec/API_SPEC.md`, FE 타입 `src/types/api.ts`)는 BIGINT 직렬화 정밀도를 이유로 `string | number` 양쪽 수용으로 작성됨. **BE 측에서 string도 허용하도록 보강**하거나, 명세를 `integer-only`로 통일해야 합니다.
+
+### 권장
+
+다음 중 하나:
+1. BE가 string도 받아 내부에서 int로 파싱 (Pydantic `Union[int, str]` + validator). FE는 양쪽 보낼 수 있음.
+2. 명세를 `integer-only`로 통일하고 FE가 호출 직전 `Number()` 강제 변환. BIGINT 정밀도가 실제로 문제되지 않는 범위라면 이 쪽이 단순.
+
+### FE 영향
+
+FE의 채팅 메시지 ID는 `msg-${Date.now()}-agent` 형태 string이라
+**BE 영속화 이슈가 풀려야 BE-recognized integer를 얻을 수 있음**. 그때까지는 메시지 북마크
+실 사용 흐름이 막힘 (chat 영속화 이슈 참조: `be-issue-chat-persistence.md`).
+
+---
+
+## 이슈 2: `DELETE /bookmarks/{id}` 307 redirect
+
+### 재현
+
+```bash
+curl -I -X DELETE -H "Authorization: Bearer $TOKEN" \
+  http://34.22.91.75:8000/api/v1/users/me/bookmarks/1
+# → HTTP/1.1 307 Temporary Redirect  (Location 헤더가 trailing slash 추가 등)
+```
+
+브라우저 `fetch`는 redirect를 자동 follow하므로 **기능은 동작합니다**(204 응답 수신).
+다만 다음 단점이 있습니다:
+
+- 한 번의 DELETE에 두 번의 왕복 발생 (지연/비용)
+- CORS preflight가 redirect 후 URL에 대해 재발생 가능 (`access-control-allow-origin` 재확인 필요)
+- 일부 클라이언트(curl 단독, 일부 HTTP 라이브러리)는 follow하지 않아 작업 실패
+
+### 의심 원인
+
+FastAPI의 `redirect_slashes=True` 기본 동작. 라우트가 `/{bookmark_id}/` (trailing slash 포함)로
+등록돼 있으면 slash 없는 요청에 307이 응답됩니다.
+
+### 권장
+
+라우터에 trailing slash 없는 형태로 통일:
+```python
+@router.delete("/{bookmark_id}")  # trailing slash 없이
+```
+또는 `APIRouter(redirect_slashes=False)`로 설정 후 두 형식 모두 직접 등록.
+
+---
+
+## 부가 정보
+
+- 재현 토큰: 기존 테스트 계정 `claude_test_1778575930@example.com` / `testpass1234` 사용 가능.
+- POST 응답 예시:
+  ```json
+  {"bookmark_id":1,"thread_id":"thread-test-1","message_id":1,
+   "pin_type":"general","preview_text":"테스트",
+   "created_at":"2026-05-12T09:32:41.844302Z"}
+  ```
+- GET 응답 예시:
+  ```json
+  {"items":[{"bookmark_id":1, ...}],"next_cursor":null}
+  ```

--- a/docs/exec-plans/active/api-integration/be-issue-chat-persistence.md
+++ b/docs/exec-plans/active/api-integration/be-issue-chat-persistence.md
@@ -1,0 +1,115 @@
+# [BE 이슈] 채팅 SSE 응답이 영속화되지 않습니다
+
+**작성**: 2026-05-12, FE
+**환경**: GCE `localbiz-api` (외부 IP `34.22.91.75:8000`), `AnyWay v0.1.0`
+**대상**: BE 채팅/스트리밍 핸들러 담당자
+
+---
+
+## 한 줄 요약
+
+`GET /api/v1/chat/stream`이 정상 응답을 스트리밍하지만 그 결과로 만들어진
+**thread와 message를 DB에 저장하지 않습니다**. 직후 호출되는 `GET /api/v1/chats`,
+`GET /api/v1/chats/{thread_id}/messages` 두 라우트가 모두 빈/404를 반환합니다.
+
+---
+
+## 책임 범위 매트릭스 (어느 API 담당자?)
+
+| 라우트 | 동작 검증 | 의심도 | 가능한 원인 |
+|---|---|---|---|
+| **`GET /api/v1/chat/stream`** | ✅ 200/SSE 응답은 정상 | **🔴 핵심** | 핸들러 내부에 **thread 생성/메시지 저장 로직 누락**. LLM 호출만 하고 DB write 안 함 |
+| `GET /api/v1/chats` | ✅ 200, 빈 배열 | 🟢 정상 | 인증/필터 OK. DB가 비어있으니 빈 응답이 맞음 |
+| `GET /api/v1/chats/{thread_id}/messages` | ✅ 404 "대화를 찾을 수 없습니다" | 🟢 정상 | DB에 thread 자체가 없어 404가 맞음 |
+| `GET /api/v1/chats/{thread_id}` | (미확인, 404 추정) | 🟢 정상 | 동일 |
+
+→ **수정 대상은 `GET /api/v1/chat/stream` 한 곳**. 다른 라우트는 stream이 영속화를
+   시작하면 자동으로 정상 동작할 것으로 보입니다.
+
+---
+
+## 재현 (curl 절차)
+
+dev BE 직접 또는 FE의 vite proxy(`http://localhost:5174`) 둘 다 동일 결과 재현됨.
+
+```bash
+BASE="http://34.22.91.75:8000"
+
+# 1) 회원가입으로 새 토큰 발급 (재현용 격리)
+EMAIL="repro_$(date +%s)@example.com"
+TOKEN=$(curl -sS -X POST -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"testpass1234\"}" \
+  "$BASE/api/v1/auth/signup" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+# 2) 초기 chats — 비어 있어야 함 (정상)
+curl -sS -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/chats"
+# → {"items":[],"next_cursor":null}
+
+# 3) SSE 스트림 호출 — 정상 응답 받음
+THREAD_ID="repro-thread-$(date +%s)"
+curl -sSN -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/v1/chat/stream?thread_id=$THREAD_ID&query=서울맛집&token=$TOKEN"
+# → event: status / intent / text_stream / done  ← 응답 자체는 OK
+
+# 4) 5초 대기 (eventual write 가능성 대비)
+sleep 5
+
+# 5) chats 재조회 — 여전히 비어 있음 ❌
+curl -sS -H "Authorization: Bearer $TOKEN" "$BASE/api/v1/chats"
+# → {"items":[],"next_cursor":null}     ← 기대: 방금 thread 1건
+
+# 6) 방금 사용한 thread_id로 messages — 404 ❌
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "$BASE/api/v1/chats/$THREAD_ID/messages"
+# → {"detail":"대화를 찾을 수 없습니다"}  ← 기대: 200 + user/assistant 메시지 2건
+```
+
+---
+
+## 기대 동작 vs 실제
+
+| 단계 | 기대 | 실제 |
+|---|---|---|
+| `/chat/stream` 호출 직후 | thread + user/assistant message 2건이 DB에 저장됨 | 저장 안 됨 |
+| `GET /chats` | 방금 thread가 `items[0]`에 포함, `title` 자동 생성(첫 user query 요약) | 빈 배열 |
+| `GET /chats/{tid}/messages` | 200 + 메시지 2건 (user query, assistant 응답) | 404 |
+
+---
+
+## 영향 받는 FE 기능
+
+FE 코드(`Phase 2 — chatStore BE 통합`)는 영속화가 활성화되는 즉시 다음을 자동 지원하도록 작성됨:
+
+- 사이드바 채팅 히스토리 자동 동기화 (`loadFromServer` → `chatsApi.list`)
+- 채팅 클릭 시 BE에서 메시지 fetch (`loadSession` → `chatsApi.messages`)
+- 채팅 삭제 (`deleteSession` → `chatsApi.delete`) — optimistic
+- 제목 변경 (`renameSession` → `chatsApi.rename`) — optimistic
+
+현재 상태에서는 위 기능이 **항상 빈 결과를 받으므로 사이드바가 새로고침마다 비워집니다.**
+
+---
+
+## 의심 코드 위치 (BE) — 확인 부탁드립니다
+
+확인 부탁드리는 영역:
+
+1. **`chat/stream` 핸들러** — LLM/LangGraph 호출 직전·직후에 다음이 있는지:
+   - 신규 `thread_id`면 `chat_threads` 테이블에 INSERT (user_id, thread_id, title)
+   - user query를 `messages` 테이블에 INSERT (role=`user`)
+   - assistant 응답(블록들)을 `messages` 테이블에 INSERT (role=`assistant`)
+   - 응답 완료 후 `chat_threads.title` 자동 생성/업데이트 (첫 query 요약)
+2. **트랜잭션/커밋** — SSE는 long-running. 응답 완료 콜백/finally에서 commit이 빠졌을 가능성.
+3. **user_id 매칭** — JWT의 `sub`(user_id)가 INSERT 시 누락되면 GET 쿼리(`WHERE user_id = ?`)에서 안 보일 수 있음.
+4. **deleted_at / 소프트 삭제 필터** — INSERT는 되는데 GET이 `WHERE deleted_at IS NULL` 같은 조건으로 가려질 가능성. (이번 케이스는 INSERT 자체가 안 되는 듯하지만 확인 차원)
+
+---
+
+## 부가 정보
+
+- 인증은 정상 (`POST /api/v1/auth/signup`, `/login` 모두 OK, 401 핸들링 OK)
+- `query`와 `token` 모두 query string으로 전달 (EventSource 한계). 보안 점검은 별도 이슈.
+- SSE 응답 자체 품질은 정상 — `status / intent / text_stream(delta) / done` 순으로 전송됨.
+- 재현 토큰 예시(만료 전까지 사용 가능):
+  - 새 가입 계정: `repro_*@example.com` / `testpass1234`
+  - 기존 테스트 계정: `claude_test_1778575930@example.com` / `testpass1234`

--- a/docs/exec-plans/active/api-integration/be-issue-google-calendar-config.md
+++ b/docs/exec-plans/active/api-integration/be-issue-google-calendar-config.md
@@ -1,0 +1,104 @@
+# [BE 이슈] Google Calendar OAuth 환경설정 누락
+
+**작성**: 2026-05-12, FE
+**환경**: GCE `localbiz-api` (`34.22.91.75:8000`)
+**대상**: BE 인증/캘린더 담당자, DevOps
+
+> `GET /api/v1/auth/google/calendar`는 200으로 `auth_url`을 발급하지만,
+> URL 내의 **`client_id` 파라미터가 빈 값**이고 **`redirect_uri`가 `localhost:8000`**으로 박혀
+> 외부 환경에서 OAuth가 실 작동하지 않습니다.
+
+---
+
+## 책임 라우트
+
+| 라우트 | 동작 | 비고 |
+|---|---|---|
+| `GET /api/v1/auth/google/calendar` | ⚠️ 200이지만 잘못된 client_id/redirect_uri | 환경변수 미적용 |
+| `GET /api/v1/auth/google/calendar/callback` | (미검증, redirect_uri가 localhost라 도달 불가) | redirect_uri 수정 후 재검증 |
+
+---
+
+## 재현
+
+```bash
+TOKEN=...   # 로그인 토큰
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  http://34.22.91.75:8000/api/v1/auth/google/calendar
+```
+
+응답 예시:
+```json
+{
+  "auth_url": "https://accounts.google.com/o/oauth2/v2/auth
+              ?client_id=
+              &redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fv1%2Fauth%2Fgoogle%2Fcalendar%2Fcallback
+              &response_type=code
+              &scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar
+              &access_type=offline
+              &prompt=consent
+              &state=..."
+}
+```
+
+→ `client_id=` 빈 값. 사용자가 이 URL로 이동하면 Google이 **`Error 401: invalid_client`** 응답.
+
+→ 동시에 `redirect_uri=http://localhost:8000/...`인데 dev BE는 GCE 외부 IP(`34.22.91.75:8000`).
+   사용자 브라우저가 localhost로 콜백 가도 BE에 도달 불가.
+
+---
+
+## 원인 추정
+
+FE 측에서 전달받은 BE `.env` 내용 (재인용):
+```
+GOOGLE_CALENDAR_CLIENT_ID=124882044304-ipl2mfoseglvhmejl6bt7f494olhli52.apps.googleusercontent.com
+GOOGLE_CALENDAR_CLIENT_SECRET=GOCSPX-...
+GOOGLE_CALENDAR_REDIRECT_URI=http://localhost:8000/api/v1/auth/google/calendar/callback
+```
+
+추정 원인:
+1. **GCE의 systemd/Docker가 `.env`를 못 읽거나 다른 .env를 사용** — `GOOGLE_CALENDAR_CLIENT_ID`가 빈 문자열로 fallback.
+2. **`GOOGLE_CALENDAR_REDIRECT_URI`가 localhost로 박힌 채 dev 배포** — 외부 IP나 dev 도메인으로 교체 필요.
+
+---
+
+## 권장 수정
+
+### 1. dev BE 환경변수 적용
+- GCE `localbiz-api` 인스턴스에서 `GOOGLE_CALENDAR_CLIENT_ID`, `GOOGLE_CALENDAR_CLIENT_SECRET` 적용 확인.
+- 우선 시작 명령에서 환경변수 노출 여부 확인:
+  ```bash
+  # GCE SSH에서
+  sudo systemctl show-environment | grep GOOGLE_CALENDAR
+  # 또는 docker exec ... env | grep GOOGLE_CALENDAR
+  ```
+- 빈 값이면 `.env` 로드 경로 또는 systemd `EnvironmentFile` 점검.
+
+### 2. `redirect_uri`를 환경별로 분리
+- dev BE: `http://34.22.91.75:8000/api/v1/auth/google/calendar/callback`
+  (또는 dev 도메인이 있다면 그쪽)
+- prod BE: 실 도메인
+- Google Cloud Console의 OAuth 클라이언트 "승인된 리디렉션 URI"에도 dev URI 추가 필요.
+
+### 3. FE에서 사용자에게 보이는 흐름 (수정 후)
+콜백 처리 BE 핸들러(`/api/v1/auth/google/calendar/callback`)는 현재 JSON `{message:"..."}` 응답.
+FE의 `/calendar/connected` 라우트로 **HTTP 302 redirect** 권장
+(`success=1` 또는 `error=access_denied` 등 쿼리 파라미터 포함).
+`src/components/share/CalendarConnected.tsx` 파일 헤더 주석에 동일 요청이 적혀 있습니다.
+
+---
+
+## FE 측에서 가능한 추가 대응
+
+- BE 환경설정이 수정되기 전까지 SettingsPage의 "Google Calendar 연동하기" 버튼에
+  `disabled` 상태 + 안내 메시지를 거는 것도 검토 가능. 다만 BE 응답을 받기 전에는
+  client_id 누락 여부를 모르므로, 누른 후 OAuth 화면에서 에러를 받는 게 현재 UX.
+- 수정 권한이 BE 측에 있어 본 보고 후 처리 결과에 따라 FE 재검증.
+
+---
+
+## 부가 정보
+
+- 우리 FE의 `googleCalendarApi.getAuthUrl()`은 정상 동작 — 받은 `auth_url`을 그대로 `window.location.href`에 할당. BE가 올바른 URL을 만들기만 하면 FE 변경 불필요.
+- 본 이슈는 별도 라우트 영역(`POST /chats/{tid}/share` 등)과 무관 — Google Calendar 핸들러만 영향.

--- a/docs/exec-plans/active/api-integration/phase-2-chat.md
+++ b/docs/exec-plans/active/api-integration/phase-2-chat.md
@@ -1,0 +1,100 @@
+# Phase 2 — 채팅 스토어 BE 통합
+
+**브랜치**: `feat/api-integration`
+**전제**: Phase 1 (인증) 통과, vite proxy 활성
+
+---
+
+## 전략
+
+### 결정: chatStore에 BE 영속성 통합 (apiChatStore swap 대신)
+
+정찰 결과 `chatStore`(localStorage)와 `apiChatStore`(BE) 인터페이스가 완전히 달라
+8개 컴포넌트(`App`, `ChatHeader`, `ChatMessages`, `ChatInputConnected`,
+`ChatSidebar`, `MessageBubble`, `StreamingMessage`, `BookmarkPanel`)를
+한 번에 모두 갈아엎으면 회귀 위험 큼.
+
+관찰: chatStore도 이미 BE SSE(`openChatStream`)를 호출 중. **유일한 갭은
+"thread 목록/메시지 히스토리 영속성"이 localStorage 기반**이라는 점.
+
+→ chatStore에 BE 영속화 액션만 추가하고 컴포넌트 변경은 0건으로 유지.
+   apiChatStore는 보존(향후 완전 마이그레이션 때 활용).
+
+---
+
+## 변경된 파일
+
+| 파일 | 변경 |
+|---|---|
+| `src/stores/chatStore.ts` | `messageItemToMessage` 어댑터 추가, `loadFromServer`/`renameSession` 신규, `loadSession`/`deleteSession` 비동기화 + BE 호출 (optimistic delete/rename) |
+| `src/App.tsx` | `useAuthStore.token` 감지 시 `loadFromServer()` 자동 호출 |
+
+컴포넌트(UI) 변경: 0건 — `useChatStore` 인터페이스 호환 유지.
+
+---
+
+## 어댑터: `MessageItem.blocks[]` → 레거시 `Message`
+
+BE는 메시지를 17종 블록 배열로 직렬화. FE 레거시 `Message`는
+`text/places/itinerary/blocks` 필드로 분리. 변환 규칙:
+
+| BE 블록 | → 레거시 Message |
+|---|---|
+| `text`, `text_stream` | `message.text` 누적 |
+| `place` | `message.places = [...]` (1건) |
+| `places` | `message.places = [...]` (n건) |
+| `course` | `message.itinerary` (첫 번째) + `itineraries` (복수) |
+| `intent`, `status`, `done`, `done_partial`, `error` | 제어 프레임 — 히스토리에 보존 안 함 |
+| 기타 (`chart`, `events`, `calendar`, `references`, `analysis_sources`, `disambiguation`, `map_markers`, `map_route`) | `message.blocks[]` |
+
+`role`: BE `assistant` → 레거시 `agent`로 매핑.
+
+---
+
+## Optimistic update 패턴
+
+- `deleteSession(id)` — 로컬 즉시 제거 → BE 호출. 실패 시 다음 `loadFromServer`에서 복원.
+- `renameSession(id, title)` — 로컬 즉시 변경 → BE 호출. 실패 시 이전 제목으로 롤백.
+- `loadSession(id)` — 비동기 (BE에서 messages fetch). 실패 시 로컬 캐시로 폴백.
+
+이유: 네트워크 왕복 대기 동안 UI freeze 방지. 기존 sync 시그니처를 호출하던
+컴포넌트(ChatSidebar, BookmarkPanel)는 fire-and-forget으로 호환됨.
+
+---
+
+## 검증 결과
+
+### 자동
+- [x] `tsc --noEmit` 통과
+- [x] `vitest run` — 13/13 tests passed (`chatStore.test.ts` `deleteSession` 테스트는
+      optimistic 패턴 덕에 sync 호출에서도 통과)
+
+### 라이브 BE 호출 (proxy 경유)
+- [x] 회원가입 → JWT 발급 (201)
+- [x] `GET /api/v1/chats` (인증 후) → 200 `{"items":[],"next_cursor":null}`
+- [x] `GET /api/v1/chat/stream` SSE → `status`/`intent`/`text_stream`/`done` 이벤트 정상 수신
+
+### 미해결 — BE 영속화 누락 (별도 보고)
+- [ ] SSE 응답을 받은 후에도 `/api/v1/chats` 빈 배열 유지
+- [ ] 직전 SSE에서 사용한 `thread_id`로 `/api/v1/chats/{id}/messages` → **404 "대화를 찾을 수 없습니다"**
+
+→ 별도 이슈 보고: [be-issue-chat-persistence.md](./be-issue-chat-persistence.md)
+
+FE 코드는 BE 영속화 활성화 시 추가 변경 없이 즉시 작동.
+
+### 브라우저 수동 (미실행, 사용자 검증 필요)
+- [ ] 로그인 후 사이드바에 BE chat 목록 노출 (BE 영속화 후 검증 가능)
+- [ ] 사이드바에서 채팅 클릭 → BE messages fetch + 메시지 렌더 (BE 영속화 후)
+- [ ] 사이드바에서 삭제 → 즉시 사라지고 새로고침 후에도 유지
+- [ ] 새 대화 시작 후 메시지 보내고 새로고침 → 사이드바에 자동 추가 (BE 영속화 후)
+
+---
+
+## 다음 Phase
+
+- **Phase 3 — 북마크 스토어 BE 통합**
+- BE에 명시적 `POST/DELETE /api/v1/users/me/bookmarks` 라우트 있어 영속화 정상 기대
+- 영향 컴포넌트: `BookmarkPanel`, `MessageBubble`
+- 패턴: chatStore와 동일하게 optimistic local + BE 동기화
+
+> Phase 2의 BE 영속화 이슈는 Phase 3 이후 BE 팀 처리 결과에 따라 재검증.

--- a/docs/exec-plans/active/api-integration/phase-3-bookmark.md
+++ b/docs/exec-plans/active/api-integration/phase-3-bookmark.md
@@ -1,0 +1,94 @@
+# Phase 3 — 북마크 스토어 BE 통합
+
+**브랜치**: `feat/api-integration`
+**전제**: Phase 1·2 통과, vite proxy 활성
+
+---
+
+## 전략
+
+### 범위 분리: 메시지 북마크만 BE 통합 (장소 북마크 보류)
+
+기존 `bookmarkStore`엔 **두 종류**의 북마크가 있음:
+1. **메시지 북마크** (`messageItems`, `toggleMessage`) — `thread_id + message_id` 컨텍스트 보유
+2. **장소 북마크** (`bookmarkedIds`, `toggle`) — `place_id`만, 5개 컴포넌트(`PlaceCard`/`PlaceCarousel`/`PlaceOverlayItem`/`MapPanel`/카드)가 사용
+
+BE 북마크 스키마(`thread_id + message_id + pin_type`)는 메시지 북마크에만 자연스럽게 매핑. 장소 북마크는 thread/message 컨텍스트가 없는 호출 경로가 많아 5개 컴포넌트 리팩토링이 필요 → 별도 Phase로 분리.
+
+Phase 3 = 메시지 북마크만 BE 동기화, 장소 북마크는 localStorage 유지.
+
+---
+
+## 변경된 파일
+
+| 파일 | 변경 |
+|---|---|
+| `src/stores/bookmarkStore.ts` | `bookmarksApi` 임포트, `bookmarkItemToMessage` / `pinTypeFromSnapshot` 어댑터 추가, `toggleMessage` / `removeMessage` 비동기화 + optimistic 패턴, `loadFromServer` 신규 |
+| `src/App.tsx` | 로그인 토큰 감지 effect에 `useBookmarkStore.loadFromServer()` 호출 추가 (기존 chat과 함께) |
+
+컴포넌트(UI) 변경: 0건 — `useBookmarkStore` 인터페이스 호환 유지(시그니처만 `Promise<void>`).
+
+---
+
+## BE → 레거시 변환
+
+BE `BookmarkItem`엔 message snapshot이 없음 → `preview_text`를 본문으로 재구성:
+
+```ts
+bookmarkItemToMessage(item) → MessageBookmarkItem {
+  bookmarkId: String(item.bookmark_id),
+  messageId: String(item.message_id),
+  conversationId: item.thread_id,
+  snapshot: { role: 'assistant', createdAt: item.created_at, content: item.preview_text ?? '' },
+  createdAt: item.created_at,
+}
+```
+
+`pin_type` 추정:
+- `snapshot.itinerary` 있으면 → `'course'`
+- `snapshot.places` 있으면 → `'place'`
+- 그 외 → `'general'`
+
+---
+
+## Optimistic 패턴
+
+- `toggleMessage(input)` — 임시 ID(`temp-mb-<msg>-<ts>`)로 즉시 추가 → BE create → 응답 `bookmark_id`로 교체. 실패 시 롤백.
+- `removeMessage(id)` — 로컬 즉시 제거 → BE delete(임시 ID면 스킵). 실패 silent.
+- `loadFromServer()` — BE list 받아서 전부 교체. 실패 silent (비로그인/네트워크).
+
+---
+
+## 검증 결과
+
+### 자동
+- [x] `tsc --noEmit` 통과
+- [x] `vitest run` — 13/13 tests passed
+
+### 라이브 BE 호출 (proxy 경유)
+- [x] `POST /api/v1/users/me/bookmarks` (message_id가 **integer**) → 201 + 응답 정상
+- [x] `GET /api/v1/users/me/bookmarks` → 즉시 list에 반영 (**영속화 OK**)
+- [x] `DELETE /api/v1/users/me/bookmarks/{id}` → 204 (브라우저 fetch는 redirect 자동 follow)
+
+### 미해결 / 차단 사항
+1. **BE는 `message_id`를 integer로만 받음** (FE 타입 정의는 `string | number`). 실 사용은 BE-recognized integer가 있어야 함.
+2. **chat 영속화 의존**: Phase 2 영속화 이슈 미해결 상태에선 메시지에 BE message_id가 없음 → 메시지 북마크 버튼을 눌러도 422가 나서 롤백됨.
+3. 별도 BE 이슈: [be-issue-bookmark-spec.md](./be-issue-bookmark-spec.md) 참조 (DELETE trailing slash 307, message_id 타입 스펙 정정).
+
+### 브라우저 수동 (Phase 2 BE 영속화 후 검증 가능)
+- [ ] 메시지에서 북마크 토글 → 즉시 노란색, BE에 영구 저장
+- [ ] 새로고침 후 BookmarkPanel에 자동 노출 (`loadFromServer`)
+- [ ] BookmarkPanel에서 제거 → BE 동기화
+- [ ] 다른 기기/브라우저 로그인 → 동일 목록 노출
+
+---
+
+## 다음 Phase
+
+- **Phase 4 — 공유 / Google Calendar OAuth / 정합성**
+- `ShareButton` 실 BE 호출 검증 (`POST /chats/{tid}/share`)
+- `SettingsPage` Google Calendar 연결 흐름 (`GET /auth/google/calendar`)
+- 타입 자동생성 (`openapi-typescript`) 도입으로 `src/types/api.ts` 정합성 자동화
+- 4상태 (Loading/Error/Empty/Populated) 잔여 보강
+
+Phase 3의 실 사용 검증은 Phase 2 BE 영속화 완료 후 재실행.

--- a/docs/exec-plans/active/api-integration/phase-4-share-calendar.md
+++ b/docs/exec-plans/active/api-integration/phase-4-share-calendar.md
@@ -1,0 +1,80 @@
+# Phase 4 — 공유 / Google Calendar OAuth + 에러 헬퍼 일반화
+
+**브랜치**: `feat/api-integration`
+**전제**: Phase 1·2·3 통과, vite proxy 활성
+
+---
+
+## 결정사항
+
+### 1. 코드 검토 결과 — 공유/캘린더 흐름은 이미 작성 완료
+- `ShareButton.tsx` → `chatsApi.share()` 호출 + 클립보드 복사 + 토스트 (작성됨)
+- `SharedPage.tsx` → `sharedApi.get(token)` (작성됨)
+- `SettingsPage.tsx` → `googleCalendarApi.getAuthUrl()` + window.location 리다이렉트 (작성됨)
+- `CalendarPanel.tsx` → 동일 (작성됨)
+- `CalendarConnected.tsx` → 콜백 후 결과 페이지 (작성됨)
+
+Phase 4의 본질적 작업은 **검증 + 에러 처리 일관화**.
+
+### 2. 에러 헬퍼 일반화 — `friendlyApiError(err, fallback)`
+기존 `friendlyAuthError`는 login/signup 전용이라 SettingsPage·ShareButton 등엔 부적합.
+- 신규 `friendlyApiError(err, fallback)`: status별 일반 한글 매핑(401/403/404/409/422/5xx/0)
+- `friendlyAuthError`는 9 / 401 특수분기만 유지 후 나머지를 `friendlyApiError`에 위임
+
+### 3. 타입 자동생성 (openapi-typescript) — Phase 5 이월
+지금 도입하면 수동 `src/types/api.ts`와 충돌 가능성 + 기존 변환 어댑터 영향. BE 라우트가 안정화되고 영속화 이슈가 풀린 뒤 도입.
+
+---
+
+## 변경된 파일
+
+| 파일 | 변경 |
+|---|---|
+| `src/lib/auth-errors.ts` | `friendlyApiError(err, fallback)` 신규, `friendlyAuthError`는 일반 케이스를 위임 |
+| `src/components/settings/SettingsPage.tsx` | 3개 catch (`updateNickname`, `getAuthUrl`, `changePassword`) → `friendlyApiError` |
+| `src/components/chat/ShareButton.tsx` | catch → `friendlyApiError` |
+| `src/components/share/SharedPage.tsx` | catch → `friendlyApiError` |
+| `src/components/calendar/CalendarPanel.tsx` | OAuth 시작 catch → `friendlyApiError` |
+
+---
+
+## 검증 결과
+
+### 자동
+- [x] `tsc --noEmit` 통과
+- [x] `vitest run` — 13/13 tests passed
+
+### 라이브 BE 호출 (proxy 경유)
+- [x] `GET /api/v1/auth/google/calendar` → 200 + `auth_url` 발급 ✅
+- [x] `POST /api/v1/chats/{tid}/share` (없는 thread) → 404 "대화를 찾을 수 없습니다" (정상 — 영속화 대기)
+- [x] `GET /shared/{nonexistent}` → 404 "공유 링크를 찾을 수 없습니다" (정상)
+
+### 차단/미해결 사항
+
+1. **Google Calendar `client_id`가 빈 값** — `auth_url` 응답엔 `client_id=` (빈 문자열).
+   BE 환경변수 `GOOGLE_CALENDAR_CLIENT_ID`가 dev 서버에 적용되지 않은 듯.
+   현 상태에서 OAuth 동의 화면이 정상 표시되지 않음.
+   → 별도 보고: [be-issue-google-calendar-config.md](./be-issue-google-calendar-config.md)
+2. **`redirect_uri`가 `http://localhost:8000`** — dev BE는 GCE 외부 IP(`34.22.91.75:8000`)인데
+   redirect_uri는 localhost. 사용자 브라우저가 콜백 시 BE에 도달 불가.
+3. **`/openapi.json`이 vite proxy 통과 안 함** — 타입 자동생성 단계에서 vite.config.ts에 추가 필요. 지금은 직접 BE 호출로 충분.
+
+### 브라우저 수동 (해결 사항 풀린 후 검증)
+- [ ] ShareButton 클릭 → 클립보드 복사 + 토스트 (chat 영속화 후)
+- [ ] `/shared/<token>` 접근 → 메시지 렌더 (Phase 2 영속화 후)
+- [ ] SettingsPage `Google Calendar 연동하기` 클릭 → 동의 화면 (BE config 수정 후)
+- [ ] OAuth 콜백 → CalendarConnected 페이지 (BE redirect 수정 후)
+
+---
+
+## 다음 Phase
+
+- **Phase 5 — 4상태 UI 보강 + 타입 자동생성 (선택)**
+  - Loading/Error/Empty/Populated 정합성 점검 (`docs/ui-detail-specs.md` 기준)
+  - 사이드바 empty state (BE 영속화 시 자연스럽게 노출)
+  - 메시지 페이징 무한 스크롤 (현재 `limit: 100` 단발 호출)
+  - `openapi-typescript` 도입 후 `src/types/api.ts` 정합성 자동화 (선택)
+
+Phase 4의 실 사용 검증은 다음 BE 이슈가 풀린 후 재실행:
+- `chat/stream` 영속화 (Phase 2 BE 이슈)
+- Google Calendar `client_id` + `redirect_uri` (Phase 4 BE 이슈)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Bookmark, MapPin, Calendar } from 'lucide-react';
 import { useChatStore } from '@/stores/chatStore';
 import { useMapStore } from '@/stores/mapStore';
 import { useBookmarkStore } from '@/stores/bookmarkStore';
+import { useAuthStore } from '@/stores/authStore';
 import { cn } from '@/lib/utils';
 import { useLocalStorage } from '@/lib/useHydrated';
 import ChatHeader from '@/components/chat/ChatHeader';
@@ -105,6 +106,9 @@ export default function App() {
   const onboarded = storedOnboarded === 'true' || onboardedOverride;
 
   const initWelcome = useChatStore((s) => s.initWelcome);
+  const loadChatsFromServer = useChatStore((s) => s.loadFromServer);
+  const loadBookmarksFromServer = useBookmarkStore((s) => s.loadFromServer);
+  const authToken = useAuthStore((s) => s.token);
   const navigation = useMapStore((s) => s.navigation);
 
   const placeCount = useBookmarkStore((s) => s.bookmarkedIds.length);
@@ -112,6 +116,13 @@ export default function App() {
   const totalBookmarks = placeCount + messageCount;
 
   useEffect(() => { initWelcome(); }, [initWelcome]);
+
+  // 로그인 직후 + 새로고침 시 BE thread/북마크 목록 동기화. 비로그인 상태에선 호출 안 함.
+  useEffect(() => {
+    if (!authToken) return;
+    loadChatsFromServer();
+    loadBookmarksFromServer();
+  }, [authToken, loadChatsFromServer, loadBookmarksFromServer]);
 
   useEffect(() => {
     if (navigation) setOverlay('map');

--- a/src/components/calendar/CalendarPanel.tsx
+++ b/src/components/calendar/CalendarPanel.tsx
@@ -4,6 +4,7 @@ import { useCalendarStore } from '@/stores/calendarStore';
 import { TRANSPORT_LABELS } from '@/lib/utils';
 import { downloadICS } from '@/lib/ics-export';
 import { googleCalendarApi } from '@/lib/api';
+import { friendlyApiError } from '@/lib/auth-errors';
 import { toast } from '@/stores/toastStore';
 import EmptyState from '@/components/ui/EmptyState';
 import type { Itinerary } from '@/types';
@@ -17,7 +18,7 @@ function GoogleCalendarConnectBar() {
       const { auth_url } = await googleCalendarApi.getAuthUrl();
       window.location.href = auth_url;
     } catch (e) {
-      toast.error((e as Error).message || '연동 URL을 불러올 수 없습니다');
+      toast.error(friendlyApiError(e, '연동 URL을 불러올 수 없습니다'));
       setBusy(false);
     }
   };

--- a/src/components/chat/ShareButton.tsx
+++ b/src/components/chat/ShareButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Share2, Check } from 'lucide-react';
 import { chatsApi } from '@/lib/api';
+import { friendlyApiError } from '@/lib/auth-errors';
 import { toast } from '@/stores/toastStore';
 
 type Props = {
@@ -51,7 +52,7 @@ export default function ShareButton({ threadId }: Props) {
         toast.info('클립보드 권한이 없어 prompt로 표시했어요');
       }
     } catch (e) {
-      const msg = (e as Error).message || '공유 실패';
+      const msg = friendlyApiError(e, '공유 링크 생성에 실패했습니다');
       setError(msg);
       toast.error(msg);
     } finally {

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { useAuthStore } from '@/stores/authStore';
 import { usersApi, googleCalendarApi } from '@/lib/api';
+import { friendlyApiError } from '@/lib/auth-errors';
 import Button from '@/components/ui/Button';
 
 export default function SettingsPage() {
@@ -31,7 +32,7 @@ export default function SettingsPage() {
       setUser({ ...user, nickname: res.nickname });
       setNicknameMsg('닉네임을 저장했습니다.');
     } catch (err) {
-      setNicknameMsg((err as Error).message || '저장 실패');
+      setNicknameMsg(friendlyApiError(err, '닉네임 저장에 실패했습니다'));
     } finally {
       setSavingNick(false);
     }
@@ -46,7 +47,7 @@ export default function SettingsPage() {
       // 동의 화면으로 전체 리다이렉트. 콜백은 BE가 직접 처리.
       window.location.href = auth_url;
     } catch (err) {
-      setCalMsg((err as Error).message || '연동 URL을 불러올 수 없습니다');
+      setCalMsg(friendlyApiError(err, '연동 URL을 불러올 수 없습니다'));
       setConnectingCal(false);
     }
   };
@@ -61,7 +62,7 @@ export default function SettingsPage() {
       setNewPw('');
       setPwMsg('비밀번호를 변경했습니다.');
     } catch (err) {
-      setPwMsg((err as Error).message || '변경 실패');
+      setPwMsg(friendlyApiError(err, '비밀번호 변경에 실패했습니다'));
     } finally {
       setSavingPw(false);
     }

--- a/src/components/share/SharedPage.tsx
+++ b/src/components/share/SharedPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { sharedApi } from '@/lib/api';
+import { friendlyApiError } from '@/lib/auth-errors';
 import type { SharedConversation } from '@/types/api';
 
 export default function SharedPage() {
@@ -24,7 +25,7 @@ export default function SharedPage() {
         if (!abort) setData(res);
       })
       .catch((e) => {
-        if (!abort) setError((e as Error).message || '공유 링크를 불러올 수 없습니다');
+        if (!abort) setError(friendlyApiError(e, '공유 링크를 불러올 수 없습니다'));
       })
       .finally(() => {
         if (!abort) setLoading(false);

--- a/src/lib/auth-errors.ts
+++ b/src/lib/auth-errors.ts
@@ -1,7 +1,23 @@
 import { ApiHttpError } from '@/lib/api';
 
+// API status 코드별 일반 한글 메시지. SettingsPage 등 도메인 무관 호출용.
+// BE 한글 메시지가 있으면 그걸 우선 노출하고, 없을 때만 status 폴백.
+export function friendlyApiError(err: unknown, fallback: string): string {
+  if (err instanceof ApiHttpError) {
+    if (err.status === 401) return err.message || '인증이 만료되었습니다. 다시 로그인해 주세요';
+    if (err.status === 403) return err.message || '접근 권한이 없습니다';
+    if (err.status === 404) return err.message || '요청한 항목을 찾을 수 없습니다';
+    if (err.status === 409) return err.message || '이미 존재하는 항목입니다';
+    if (err.status === 422) return err.message || '입력값을 확인해 주세요';
+    if (err.status >= 500) return '서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요';
+    if (err.status === 0 || err.message === 'Timeout') return '네트워크 연결을 확인해 주세요';
+    if (err.message) return err.message;
+  }
+  return (err as Error)?.message || fallback;
+}
+
 // Login/Signup 양 페이지가 공유하는 에러 메시지 매핑.
-// BE 응답이 영문이거나 HTTP status로만 의미가 드러나는 케이스를 한글 폴백으로 정규화.
+// 일반 정책은 friendlyApiError에 위임하고, 인증 특수 케이스만 별도 분기.
 export function friendlyAuthError(err: unknown, mode: 'login' | 'signup'): string {
   if (err instanceof ApiHttpError) {
     if (err.status === 409) return '이미 가입된 이메일입니다';
@@ -9,16 +25,9 @@ export function friendlyAuthError(err: unknown, mode: 'login' | 'signup'): strin
       // BE가 이미 한글로 응답 (예: "이메일 또는 비밀번호가 올바르지 않습니다") — 그대로 사용.
       return err.message || '이메일 또는 비밀번호가 올바르지 않습니다';
     }
-    if (err.status === 422) {
-      // extractErrorMessage가 Pydantic 배열을 한글로 변환해 message에 담아둠.
-      return err.message || '입력값을 확인해 주세요';
-    }
-    if (err.status >= 500) return '서버 오류가 발생했습니다. 잠시 후 다시 시도해 주세요';
-    if (err.status === 0 || err.message === 'Timeout') return '네트워크 연결을 확인해 주세요';
-    if (err.message) return err.message;
   }
-  return (
-    (err as Error)?.message ||
-    (mode === 'login' ? '로그인에 실패했습니다' : '회원가입에 실패했습니다')
+  return friendlyApiError(
+    err,
+    mode === 'login' ? '로그인에 실패했습니다' : '회원가입에 실패했습니다',
   );
 }

--- a/src/stores/bookmarkStore.ts
+++ b/src/stores/bookmarkStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 import type { Place, MessageBookmarkItem, MessageSnapshot } from '@/types';
+import type { BookmarkItem, PinType } from '@/types/api';
+import { bookmarksApi } from '@/lib/api';
 import placesData from '@/mocks/places.json';
 
 const allPlaces = placesData as Place[];
@@ -67,8 +69,34 @@ interface ToggleMessageInput {
   snapshot: MessageSnapshot;
 }
 
+// snapshot 내용으로 BE의 pin_type 추정. 명시적 종류가 없으면 'general'.
+function pinTypeFromSnapshot(s: MessageSnapshot): PinType {
+  if (s.itinerary) return 'course';
+  if (s.places && s.places.length > 0) return 'place';
+  return 'general';
+}
+
+// BE 응답엔 snapshot이 없으므로 preview_text를 본문으로 재구성.
+function bookmarkItemToMessage(item: BookmarkItem): MessageBookmarkItem {
+  return {
+    bookmarkId: String(item.bookmark_id),
+    messageId: String(item.message_id),
+    conversationId: item.thread_id,
+    snapshot: {
+      role: 'assistant',
+      createdAt: item.created_at,
+      content: item.preview_text ?? '',
+    },
+    createdAt: item.created_at,
+  };
+}
+
+// 로컬 추가 시 BE 호출 전 임시로 부여하는 ID prefix. 동기화 후 BE id로 교체됨.
+const TEMP_BOOKMARK_PREFIX = 'temp-mb-';
+const isTempBookmark = (id: string): boolean => id.startsWith(TEMP_BOOKMARK_PREFIX);
+
 interface BookmarkStore {
-  // Place bookmarks
+  // Place bookmarks (localStorage only — phase 3에선 BE 통합 보류)
   bookmarkedIds: string[];
   // SSE-driven 장소(places.json에 없는)도 카드에 노출되도록 스냅샷 보관.
   placeSnapshots: Record<string, Place>;
@@ -79,11 +107,13 @@ interface BookmarkStore {
   isBookmarked: (id: string) => boolean;
   getBookmarkedPlaces: () => Place[];
 
-  // Message bookmarks (new)
+  // Message bookmarks (BE 동기화)
   messageItems: MessageBookmarkItem[];
-  toggleMessage: (input: ToggleMessageInput) => void;
-  removeMessage: (messageId: string) => void;
+  toggleMessage: (input: ToggleMessageInput) => Promise<void>;
+  removeMessage: (messageId: string) => Promise<void>;
   isMessageBookmarked: (messageId: string) => boolean;
+  // BE에서 메시지 북마크 목록 동기화. 비로그인/실패 시 silent.
+  loadFromServer: () => Promise<void>;
 }
 
 // 초기 ID 중 places.json에도 없고 snapshots에도 없으면 stale → 제거.
@@ -146,31 +176,80 @@ export const useBookmarkStore = create<BookmarkStore>((set, get) => ({
       .filter((p): p is Place => p !== undefined);
   },
 
-  toggleMessage: ({ messageId, conversationId, snapshot }) => {
+  toggleMessage: async ({ messageId, conversationId, snapshot }) => {
     const { messageItems } = get();
-    const exists = messageItems.some((m) => m.messageId === messageId);
-    const next = exists
-      ? messageItems.filter((m) => m.messageId !== messageId)
-      : [
-          {
-            bookmarkId: `mb_${messageId}`,
-            messageId,
-            conversationId,
-            snapshot,
-            createdAt: new Date().toISOString(),
-          },
-          ...messageItems,
-        ];
-    saveMessageItems(next);
-    set({ messageItems: next });
+    const existing = messageItems.find((m) => m.messageId === messageId);
+
+    if (existing) {
+      // 이미 북마크돼 있음 → 해제. removeMessage가 BE delete까지 처리.
+      await get().removeMessage(messageId);
+      return;
+    }
+
+    // Optimistic 추가 — BE 응답 오기 전 임시 ID로 표시.
+    const tempId = `${TEMP_BOOKMARK_PREFIX}${messageId}-${Date.now()}`;
+    const optimistic: MessageBookmarkItem = {
+      bookmarkId: tempId,
+      messageId,
+      conversationId,
+      snapshot,
+      createdAt: new Date().toISOString(),
+    };
+    const optimisticItems = [optimistic, ...messageItems];
+    saveMessageItems(optimisticItems);
+    set({ messageItems: optimisticItems });
+
+    try {
+      const res = await bookmarksApi.create({
+        thread_id: conversationId,
+        message_id: messageId,
+        pin_type: pinTypeFromSnapshot(snapshot),
+        preview_text: snapshot.content?.slice(0, 200) || undefined,
+      });
+      // BE id로 교체
+      const updated = get().messageItems.map((m) =>
+        m.bookmarkId === tempId
+          ? { ...m, bookmarkId: String(res.bookmark_id), createdAt: res.created_at }
+          : m,
+      );
+      saveMessageItems(updated);
+      set({ messageItems: updated });
+    } catch {
+      // 롤백 — 비로그인이거나 BE 실패. 로컬에서도 제거.
+      const rolled = get().messageItems.filter((m) => m.bookmarkId !== tempId);
+      saveMessageItems(rolled);
+      set({ messageItems: rolled });
+    }
   },
 
-  removeMessage: (messageId) => {
+  removeMessage: async (messageId) => {
+    const target = get().messageItems.find((m) => m.messageId === messageId);
+    // Optimistic 제거 — UI는 즉시 반응. BE는 백그라운드 호출.
     const next = get().messageItems.filter((m) => m.messageId !== messageId);
     saveMessageItems(next);
     set({ messageItems: next });
+
+    if (!target) return;
+    // 아직 BE에 만들어지지 않은 임시 항목이면 BE 호출 스킵.
+    if (isTempBookmark(target.bookmarkId)) return;
+    try {
+      await bookmarksApi.delete(target.bookmarkId);
+    } catch {
+      // silent — 다음 loadFromServer에서 진실 복구.
+    }
   },
 
   isMessageBookmarked: (messageId) =>
     get().messageItems.some((m) => m.messageId === messageId),
+
+  loadFromServer: async () => {
+    try {
+      const res = await bookmarksApi.list({ limit: 100 });
+      const items = res.items.map(bookmarkItemToMessage);
+      saveMessageItems(items);
+      set({ messageItems: items });
+    } catch {
+      // 비로그인 / 네트워크 실패 — 로컬 유지.
+    }
+  },
 }));

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand';
 import type { AgentType, Message, Place, Itinerary, PlaceCategory, TransportMode } from '@/types';
-import type { Block, PlaceBlockData, PlacesBlock, CourseBlock } from '@/types/api';
+import type { Block, PlaceBlockData, PlacesBlock, CourseBlock, MessageItem } from '@/types/api';
 import { getWelcomeMessage } from '@/mocks/agent-responses';
 import { openChatStream } from '@/lib/sse';
+import { chatsApi } from '@/lib/api';
 import { useMapStore } from './mapStore';
 
 // SSE 블록 → 레거시 Message 타입 어댑터.
@@ -71,6 +72,57 @@ function courseBlockToItinerary(block: CourseBlock): Itinerary {
   };
 }
 
+// BE의 MessageItem(blocks[]) → 레거시 Message로 변환.
+// place/places → places, course → itinerary/itineraries, text/text_stream → text,
+// intent/status/done/error 같은 제어 프레임은 무시(히스토리에는 의미 없음).
+function messageItemToMessage(item: MessageItem, threadId: string): Message {
+  const blocks: Block[] = item.blocks ?? [];
+  let text = '';
+  let places: Place[] | undefined;
+  let itinerary: Itinerary | undefined;
+  const itineraries: Itinerary[] = [];
+  const otherBlocks: Block[] = [];
+
+  for (const b of blocks) {
+    if (b.type === 'text') {
+      text += b.content;
+    } else if (b.type === 'text_stream') {
+      text += b.delta;
+    } else if (b.type === 'place') {
+      places = [singlePlaceBlockToPlace(b)];
+    } else if (b.type === 'places') {
+      places = placesBlockToPlaces(b);
+    } else if (b.type === 'course') {
+      const it = courseBlockToItinerary(b);
+      itineraries.push(it);
+      if (!itinerary) itinerary = it;
+    } else if (
+      b.type === 'intent' ||
+      b.type === 'status' ||
+      b.type === 'done' ||
+      b.type === 'done_partial' ||
+      b.type === 'error'
+    ) {
+      // 제어 프레임은 메시지 본문에 보존하지 않음.
+    } else {
+      otherBlocks.push(b);
+    }
+  }
+
+  return {
+    id: String(item.message_id),
+    role: item.role === 'assistant' ? 'agent' : 'user',
+    text,
+    timestamp: item.created_at,
+    places,
+    itinerary,
+    itineraries: itineraries.length > 1 ? itineraries : undefined,
+    blocks: otherBlocks.length > 0 ? otherBlocks : undefined,
+    threadId,
+    messageId: item.message_id,
+  };
+}
+
 export interface ChatSession {
   id: string;
   title: string;
@@ -96,8 +148,11 @@ interface ChatStore {
   clearChat: () => void;
   initWelcome: () => void;
   newChat: () => void;
-  loadSession: (sessionId: string) => void;
-  deleteSession: (sessionId: string) => void;
+  loadSession: (sessionId: string) => Promise<void>;
+  deleteSession: (sessionId: string) => Promise<void>;
+  renameSession: (sessionId: string, title: string) => Promise<void>;
+  // BE에서 thread 목록 동기화. 비로그인/실패 시 silent.
+  loadFromServer: () => Promise<void>;
 }
 
 function generateSessionTitle(messages: Message[]): string {
@@ -315,23 +370,102 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }, 0);
   },
 
-  loadSession: (id: string) => {
-    const { sessions } = get();
-    const session = sessions.find((s) => s.id === id);
-    if (!session) return;
-    set({
-      sessionId: session.id,
-      messages: session.messages,
-      selectedAgent: session.agent,
-      streamingText: '',
-      isLoading: false,
-    });
+  loadSession: async (id: string) => {
+    const { sessions, selectedAgent } = get();
+    const existing = sessions.find((s) => s.id === id);
+    try {
+      const res = await chatsApi.messages(id, { limit: 100 });
+      const messages = res.items.map((it) => messageItemToMessage(it, id));
+      const now = new Date().toISOString();
+      const session: ChatSession = existing
+        ? { ...existing, messages, updatedAt: now }
+        : { id, title: '새 대화', agent: selectedAgent, messages, createdAt: now, updatedAt: now };
+      set({
+        sessionId: id,
+        messages,
+        selectedAgent: session.agent,
+        streamingText: '',
+        isLoading: false,
+        sessions: existing
+          ? sessions.map((s) => (s.id === id ? session : s))
+          : [session, ...sessions],
+      });
+    } catch {
+      // BE 실패 시 로컬 캐시로 폴백.
+      if (existing) {
+        set({
+          sessionId: existing.id,
+          messages: existing.messages,
+          selectedAgent: existing.agent,
+          streamingText: '',
+          isLoading: false,
+        });
+      }
+    }
   },
 
-  deleteSession: (id: string) => {
+  deleteSession: async (id: string) => {
+    // Optimistic — 로컬에서 즉시 제거. BE 실패해도 다음 loadFromServer에서 복원됨.
+    const state = get();
+    if (state.sessionId === id) {
+      set({
+        sessions: state.sessions.filter((s) => s.id !== id),
+        sessionId: `session-${Date.now()}`,
+        messages: [],
+        streamingText: '',
+        isLoading: false,
+      });
+    } else {
+      set({ sessions: state.sessions.filter((s) => s.id !== id) });
+    }
+    try {
+      await chatsApi.delete(id);
+    } catch {
+      // silent — 다음 새로고침에 BE 진실로 복구
+    }
+  },
+
+  renameSession: async (id: string, title: string) => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    // Optimistic 적용 + 실패 시 되돌림.
+    const prev = get().sessions.find((s) => s.id === id)?.title ?? null;
     set((state) => ({
-      sessions: state.sessions.filter((s) => s.id !== id),
+      sessions: state.sessions.map((s) =>
+        s.id === id ? { ...s, title: trimmed, updatedAt: new Date().toISOString() } : s,
+      ),
     }));
+    try {
+      await chatsApi.rename(id, trimmed);
+    } catch {
+      // 롤백 (BE에서 거절). prev가 null이면 그냥 두기.
+      if (prev !== null) {
+        set((state) => ({
+          sessions: state.sessions.map((s) => (s.id === id ? { ...s, title: prev } : s)),
+        }));
+      }
+    }
+  },
+
+  loadFromServer: async () => {
+    try {
+      const res = await chatsApi.list({ limit: 50 });
+      const selectedAgent = get().selectedAgent;
+      const serverSessions: ChatSession[] = res.items.map((t) => ({
+        id: t.thread_id,
+        title: t.title ?? '새 대화',
+        agent: selectedAgent,
+        messages: [],
+        createdAt: t.updated_at,
+        updatedAt: t.updated_at,
+      }));
+      // 로컬-only 세션(아직 BE에 메시지 전송 안 한 새 대화)은 보존.
+      const serverIds = new Set(serverSessions.map((s) => s.id));
+      const localOnly = get().sessions.filter((s) => !serverIds.has(s.id));
+      set({ sessions: [...serverSessions, ...localOnly] });
+    } catch {
+      // 비로그인 또는 네트워크 실패 — silent.
+    }
   },
 
   clearChat: () => set({ messages: [], isLoading: false, streamingText: '' }),


### PR DESCRIPTION
## Summary
- `friendlyApiError(err, fallback)` 신규 — status별 일반 한글 매핑 (401/403/404/409/422/5xx/0 + 네트워크)
- `friendlyAuthError`는 401/409 인증 특수분기만 유지 후 위임
- 4개 컴포넌트 catch 한글화: `SettingsPage`(3곳), `ShareButton`, `SharedPage`, `CalendarPanel`
- 공유/캘린더 코드 자체는 이미 작성돼 있어 본 PR은 **검증 + 에러 처리 일관화**

## Base PR
#56 (Phase 2+3) 위에 쌓입니다.

## 알려진 BE 차단 이슈 (별도 보고)
- **Google Calendar `client_id`가 빈 값** — BE 환경변수 `GOOGLE_CALENDAR_CLIENT_ID` 미적용
- **`redirect_uri=localhost:8000`** — 외부 환경에서 OAuth 콜백 불가
- 보고: `docs/exec-plans/active/api-integration/be-issue-google-calendar-config.md`

## Test plan
- [x] `pnpm tsc --noEmit` 통과
- [x] `pnpm test:run` — 13/13
- [x] curl: `GET /api/v1/auth/google/calendar` 200 + `auth_url` 발급 (client_id 빈 값 확인)
- [x] curl: `GET /shared/{nonexistent}` 404 한글
- [ ] (BE Calendar 설정 후) Settings → "Google Calendar 연동하기" → 동의 화면 정상 노출
- [ ] (chat 영속화 후) ShareButton → 토스트 + 클립보드 복사
- [ ] (chat 영속화 후) `/shared/<token>` 메시지 렌더

🤖 Generated with [Claude Code](https://claude.com/claude-code)