### PR TITLE
fix(vercel): prod 405 — BE same-origin proxy rewrites 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,9 @@
   "outputDirectory": "dist",
   "installCommand": "pnpm install",
   "rewrites": [
+    { "source": "/api/:path*", "destination": "http://34.22.91.75:8000/api/:path*" },
+    { "source": "/health", "destination": "http://34.22.91.75:8000/health" },
+    { "source": "/shared/:path*", "destination": "http://34.22.91.75:8000/shared/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## 증상
prod 빌드에서 `/api/v1/*` 요청에 **405 Method Not Allowed** 발생.

## 원인
`VITE_API_BASE=` (빈 값)이라 FE가 vercel 도메인 자체에 `/api/v1/*` 요청을 보냄.
vercel은 정적 SPA 호스팅이라 POST 거부 → 405.

## 해결
`vercel.json` rewrites에 BE proxy 3건을 SPA catch-all 앞에 추가:
- `/api/:path*` → `http://34.22.91.75:8000/api/:path*`
- `/health` → BE
- `/shared/:path*` → BE

vercel 서버가 server-side forward하므로:
- 브라우저는 same-origin HTTPS만 봄 → **mixed content 회피**
- preflight 발생 안 함 → **CORS 회피**
- dev (`vite.config.ts proxy`)와 prod 동일 패턴

## Test plan
- [ ] Vercel preview 배포 → `/api/v1/chats`가 BE 응답 받는지 확인
- [ ] 로그인/회원가입 흐름 prod에서 동작
- [ ] SSE (`/api/v1/chat/stream`) 작동 — vercel edge 타임아웃(Hobby 10s / Pro 60s)에 주의

## 후속 권장
- BE에 HTTPS 도메인 붙이면 vercel proxy hop 제거 가능 (장기)
- SSE가 vercel 타임아웃에 걸리면 BE 직접 HTTPS 호출로 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)