### PR TITLE
fix(vercel): BE proxy를 HTTPS nip.io 도메인으로 전환

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,9 @@
   "outputDirectory": "dist",
   "installCommand": "pnpm install",
   "rewrites": [
-    { "source": "/api/:path*", "destination": "http://34.22.91.75:8000/api/:path*" },
-    { "source": "/health", "destination": "http://34.22.91.75:8000/health" },
-    { "source": "/shared/:path*", "destination": "http://34.22.91.75:8000/shared/:path*" },
+    { "source": "/api/:path*", "destination": "https://34.22.91.75.nip.io/api/:path*" },
+    { "source": "/health", "destination": "https://34.22.91.75.nip.io/health" },
+    { "source": "/shared/:path*", "destination": "https://34.22.91.75.nip.io/shared/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
BE 앞에 nginx 리버스 프록시가 붙어 HTTPS 종단 처리됨.
`vercel.json` rewrites 3개 destination을 HTTP IP → HTTPS 도메인으로 변경:

- `http://34.22.91.75:8000/...` → `https://34.22.91.75.nip.io/...`

## 검증 완료 (PR 생성 전)
- `GET https://34.22.91.75.nip.io/health` → 200 (nginx 1.22.1 → uvicorn)
- BE CORS preflight: `access-control-allow-origin: https://seoul-ai-guide.vercel.app` 명시 허용
- HTTPS 8000 포트는 nginx 미적용 — 443만 가능 (도메인만 사용)

## 이점
- 평문 → HTTPS 통신
- vercel hop 유지: preview URL도 same-origin이라 CORS 영향 0

## Test plan
- [ ] 머지 후 Vercel 자동 재배포
- [ ] prod에서 로그인 → 메인 진입 동작 확인
- [ ] SSE 스트림 정상 작동 (vercel edge 타임아웃 주의)

🤖 Generated with [Claude Code](https://claude.com/claude-code)