### PR TITLE
사이드바 제목 편집 + 일정 BE 연동 + 공유 페이지 풍부 렌더

### DIFF
--- a/docs/be-requests.md
+++ b/docs/be-requests.md
@@ -179,6 +179,153 @@ class EventItem(BaseModel):
 
 ---
 
+## 9. 대화 북마크 422 — DoneBlock에 message_id 추가 (Active)
+
+**상태**: 🔴 BE 요청 필요. 현재 응답 직후 북마크 시 422 발생.
+
+**증상**: 사용자가 응답 받자마자 북마크 누르면 **422 Unprocessable Entity**. 새로고침/탭 전환 후엔 정상.
+
+**원인**:
+- `BookmarkCreateRequest.message_id: int` (BE schema)
+- FE는 SSE 응답 후 BE에 저장된 메시지의 진짜 `message_id`를 알 방법이 없어서, fresh local string id(`"msg-1234567890-agent"`)를 그대로 보냄
+- Pydantic int validation 실패 → 422
+- 새로고침하면 `loadFromServer`가 히스토리에서 real int id로 메시지 재로드 → 북마크 가능
+
+**원인 파일**: `backend/src/models/blocks.py:308`의 `DoneBlock`에 `message_id` 필드 없음.
+
+**요청**:
+```python
+class DoneBlock(BaseModel):
+    type: str = "done"
+    status: str = "done"
+    error_message: Optional[str] = None
+    message_id: Optional[int] = None       # ← 신규 (assistant 메시지 id)
+    user_message_id: Optional[int] = None  # ← (선택) user 메시지 id
+```
+
+→ FE는 `done` 이벤트 받을 때 local agent 메시지의 `messageId`를 BE id로 즉시 교체. 사용자가 응답 직후 북마크해도 정상 동작.
+
+**FE 측 작업 (BE 머지 후)**:
+- `chatStore.ts`의 `done` 핸들러에서 `data.message_id`로 local 메시지 id 갱신 한 줄 추가.
+
+---
+
+## 10. 장소 북마크 BE API 신규 (Active)
+
+**상태**: 🔴 BE 신규 작업 필요. 현재 FE는 localStorage만 사용.
+
+**증상/현황**: 사용자가 PlaceCard ★ 누른 장소가 **현재 브라우저에만 저장**됨. 디바이스 간 동기화 X, 캐시 지우면 사라짐, 계정 따라가지 않음.
+
+**원인**: BE에 장소 북마크 endpoint 미구현. 대화 북마크(`bookmarks` 테이블)는 메시지 컨텍스트 강제(`thread_id` + `message_id` 필수)라 장소 단독 북마크에 부적합.
+
+**요청**: **별도 테이블 + 별도 endpoint 3종** 신규 구현.
+
+### 엔드포인트 설계
+
+**POST `/api/v1/users/me/place-bookmarks`** — 추가
+```python
+class PlaceBookmarkCreateRequest(BaseModel):
+    place_id: str = Field(..., min_length=1, max_length=100)
+    name: str = Field(..., max_length=200)
+    # 시점 스냅샷
+    category: Optional[str] = None
+    address: Optional[str] = None
+    district: Optional[str] = None
+    lat: Optional[float] = None
+    lng: Optional[float] = None
+    rating: Optional[float] = None
+    image_url: Optional[str] = None
+    summary: Optional[str] = Field(None, max_length=500)
+    # 발견 출처 (선택)
+    source_thread_id: Optional[str] = None
+    source_message_id: Optional[int] = None
+```
+
+**GET `/api/v1/users/me/place-bookmarks`** — 목록 (cursor 페이지네이션, `created_at DESC` 정렬)
+
+**DELETE `/api/v1/users/me/place-bookmarks/{bookmark_id}`** — 삭제 (soft delete, 대화 북마크와 일관)
+
+### DB 테이블
+
+```sql
+CREATE TABLE place_bookmarks (
+  bookmark_id     BIGSERIAL PRIMARY KEY,
+  user_id         BIGINT NOT NULL REFERENCES users(user_id),
+  place_id        VARCHAR(100) NOT NULL,
+  name            VARCHAR(200) NOT NULL,
+  category        VARCHAR(50),
+  address         TEXT,
+  district        VARCHAR(50),
+  lat             DOUBLE PRECISION,
+  lng             DOUBLE PRECISION,
+  rating          REAL,
+  image_url       TEXT,
+  summary         TEXT,
+  source_thread_id  VARCHAR(100),
+  source_message_id BIGINT,
+  is_deleted      BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at      TIMESTAMPTZ,
+  UNIQUE(user_id, place_id)
+);
+
+CREATE INDEX idx_place_bookmarks_user_created
+  ON place_bookmarks(user_id, created_at DESC)
+  WHERE is_deleted = FALSE;
+```
+
+### 핵심 결정 사항
+
+1. **`(user_id, place_id)` UNIQUE** — 중복 시 **idempotent 200 OK** 반환 권장 (FE 마이그레이션 친화)
+2. **시점 스냅샷 보관** — places 테이블 데이터가 변해도(휴업/폐점/이름 변경) 북마크엔 영향 X
+3. **`source_thread_id`/`source_message_id`** — 어느 대화에서 발견했는지 추적 (분석/UX, 선택)
+4. **Soft delete** — 대화 북마크와 패턴 통일
+5. **Auth** — JWT 필수, 비로그인은 401
+
+### FE 측 작업 (BE 완성 후)
+
+1. `src/lib/api.ts`에 `placeBookmarksApi` 추가 (대화 북마크 패턴 그대로)
+2. `bookmarkStore.toggle`/`add`/`remove`에 BE 호출 + optimistic 패턴 (대화 북마크 `toggleMessage` 참고)
+3. `loadFromServer`에서 장소 북마크 동시 fetch
+4. 로그인 직후 기존 localStorage 데이터 → BE 일괄 migrate (idempotent라 안전)
+
+---
+
+## 11. 캘린더 OAuth callback — FE 페이지 redirect (Active)
+
+**상태**: 🔴 BE 한 줄 수정 필요. 현재 사용자가 raw JSON 페이지 봄.
+
+**증상**: 캘린더 연동 OAuth 흐름 자체는 정상 완료. 단, 마지막에 **`{"message":"Google Calendar 연동이 완료되었습니다."}` JSON이 그대로 브라우저에 표시**됨. FE의 "연동 완료" 페이지(`CalendarConnected`)가 안 보임.
+
+**원인**: `backend/src/api/google_calendar_auth.py:175`
+```python
+return {"message": "Google Calendar 연동이 완료되었습니다."}
+```
+→ FastAPI가 dict를 JSON 응답으로 직렬화. 브라우저는 raw JSON 페이지 표시.
+
+**요청**:
+```python
+from fastapi.responses import RedirectResponse
+
+# 성공 시
+return RedirectResponse(
+    url="https://seoul-ai-guide.vercel.app/calendar/connected",
+    status_code=302,
+)
+
+# 에러 시 (선택)
+return RedirectResponse(
+    url=f"https://seoul-ai-guide.vercel.app/calendar/connected?error={error_code}",
+    status_code=302,
+)
+```
+
+production / dev / local 환경별 FE base URL은 `FE_BASE_URL` 같은 환경변수로 분리 권장.
+
+**FE 측**: `src/main.tsx:65`에 `<Route path="/calendar/connected">` 이미 존재. `?error=` 쿼리 파라미터 처리도 `CalendarConnected.tsx`에 완성됨. BE redirect만 추가되면 즉시 동작.
+
+---
+
 ## 해소된 이슈 (Resolved — 기록용)
 
 ### R1. text_stream 블록 필드명 (라이브 vs 저장본)

--- a/src/components/bookmark/BookmarkPanel.tsx
+++ b/src/components/bookmark/BookmarkPanel.tsx
@@ -1,6 +1,15 @@
 import { useMemo, useState } from 'react';
 import { MessageSquare, MapPin, Sparkles, Trash2 } from 'lucide-react';
-import type { MessageBookmarkItem, Place } from '@/types';
+import type { BookmarkPinType, MessageBookmarkItem, Place } from '@/types';
+
+// 북마크 핀 타입별 칩 — 88 팔레트 매핑. general은 별도 표시 X (기본).
+const PIN_TYPE_CONFIG: Record<BookmarkPinType, { label: string; color: string; bg: string } | null> = {
+  place:    { label: '장소', color: '#1F3A8B', bg: '#1F3A8B14' },
+  event:    { label: '행사', color: '#F4A12C', bg: '#F4A12C14' },
+  course:   { label: '코스', color: '#00853E', bg: '#00853E14' },
+  analysis: { label: '분석', color: '#6B7280', bg: '#6B728014' },
+  general:  null,
+};
 import { CATEGORY_CONFIG, cn } from '@/lib/utils';
 import { useBookmarkStore } from '@/stores/bookmarkStore';
 import { useMapStore } from '@/stores/mapStore';
@@ -245,6 +254,7 @@ function MessageBookmarks({ items, onClose }: { items: MessageBookmarkItem[]; on
       {grouped.map((item) => {
         const relDate = formatRelativeDate(item.createdAt);
         const placeCount = item.snapshot.places?.length ?? 0;
+        const pinChip = PIN_TYPE_CONFIG[item.pinType];
 
         return (
           <article
@@ -253,6 +263,14 @@ function MessageBookmarks({ items, onClose }: { items: MessageBookmarkItem[]; on
             onClick={() => { loadSession(item.conversationId); onClose?.(); }}
           >
             <div className="flex items-center gap-2 mb-2">
+              {pinChip && (
+                <span
+                  className="text-[10px] font-semibold px-1.5 py-0.5 rounded-md tracking-tight"
+                  style={{ color: pinChip.color, backgroundColor: pinChip.bg }}
+                >
+                  {pinChip.label}
+                </span>
+              )}
               <span className="text-[11px] text-text-muted">{relDate}</span>
 
               <button

--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -1,5 +1,5 @@
-import { memo } from 'react';
-import { X, Plus, MessageCircle, Trash2, Settings, LogOut, User, RefreshCw } from 'lucide-react';
+import { memo, useState, useRef, useEffect, useCallback, type KeyboardEvent, type FocusEvent } from 'react';
+import { X, Plus, MessageCircle, Trash2, Settings, LogOut, User, RefreshCw, Pencil, Check } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useChatStore, type ChatSession } from '@/stores/chatStore';
 import { useAuthStore } from '@/stores/authStore';
@@ -32,6 +32,7 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
   const newChat = useChatStore((s) => s.newChat);
   const loadSession = useChatStore((s) => s.loadSession);
   const deleteSession = useChatStore((s) => s.deleteSession);
+  const renameSession = useChatStore((s) => s.renameSession);
   const chatsLoading = useChatStore((s) => s.chatsLoading);
   const chatsError = useChatStore((s) => s.chatsError);
   const loadFromServer = useChatStore((s) => s.loadFromServer);
@@ -123,39 +124,16 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
               </div>
             )
           ) : (
-            sessions.map((session: ChatSession) => {
-              const isActive = session.id === sessionId;
-              return (
-                <div
-                  key={session.id}
-                  className={cn(
-                    'group flex items-start gap-2.5 px-3 py-2.5 rounded-xl cursor-pointer transition-all duration-150',
-                    isActive ? 'bg-brand-subtle' : 'hover:bg-bg-subtle',
-                  )}
-                  onClick={() => handleLoadSession(session.id)}
-                >
-                  <div className="w-[6px] h-[6px] rounded-full mt-[7px] shrink-0 bg-brand" />
-                  <div className="flex-1 min-w-0">
-                    <p className={cn(
-                      'text-[13px] leading-tight truncate',
-                      isActive ? 'font-semibold text-brand' : 'font-medium text-text-primary',
-                    )}>
-                      {session.title}
-                    </p>
-                    <p className="text-[11px] text-text-muted mt-1">
-                      {formatDate(session.updatedAt)}
-                    </p>
-                  </div>
-                  <button
-                    onClick={(e) => { e.stopPropagation(); deleteSession(session.id); }}
-                    className="opacity-0 group-hover:opacity-100 w-6 h-6 rounded-md flex items-center justify-center text-text-muted hover:text-[#DC2626] hover:bg-[#FEF2F2] transition-all cursor-pointer shrink-0 mt-0.5"
-                    aria-label="대화 삭제"
-                  >
-                    <Trash2 size={12} />
-                  </button>
-                </div>
-              );
-            })
+            sessions.map((session: ChatSession) => (
+              <SessionItem
+                key={session.id}
+                session={session}
+                isActive={session.id === sessionId}
+                onLoad={handleLoadSession}
+                onDelete={deleteSession}
+                onRename={renameSession}
+              />
+            ))
           )}
         </div>
 
@@ -198,3 +176,128 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
     </>
   );
 });
+
+// 사이드바 세션 카드 — 인라인 제목 편집 지원.
+// Pencil: 편집 진입 / Enter or blur: 저장 / Escape: 취소.
+interface SessionItemProps {
+  session: ChatSession;
+  isActive: boolean;
+  onLoad: (id: string) => void;
+  onDelete: (id: string) => void;
+  onRename: (id: string, title: string) => Promise<void>;
+}
+
+function SessionItem({ session, isActive, onLoad, onDelete, onRename }: SessionItemProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(session.title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  // 외부에서 title이 바뀌면 (BE rename 동기화 등) draft도 동기화.
+  useEffect(() => {
+    if (!editing) setDraft(session.title);
+  }, [session.title, editing]);
+
+  const commit = useCallback(async () => {
+    const trimmed = draft.trim();
+    setEditing(false);
+    if (!trimmed || trimmed === session.title) {
+      setDraft(session.title);
+      return;
+    }
+    await onRename(session.id, trimmed).catch(() => {
+      // 실패 시 원래 값 복구.
+      setDraft(session.title);
+    });
+  }, [draft, session.id, session.title, onRename]);
+
+  const cancel = useCallback(() => {
+    setDraft(session.title);
+    setEditing(false);
+  }, [session.title]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void commit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  };
+
+  const handleBlur = (_e: FocusEvent<HTMLInputElement>) => {
+    void commit();
+  };
+
+  return (
+    <div
+      className={cn(
+        'group flex items-start gap-2.5 px-3 py-2.5 rounded-xl transition-all duration-150',
+        editing ? 'cursor-default' : 'cursor-pointer',
+        isActive ? 'bg-brand-subtle' : 'hover:bg-bg-subtle',
+      )}
+      onClick={() => { if (!editing) onLoad(session.id); }}
+    >
+      <div className="w-[6px] h-[6px] rounded-full mt-[7px] shrink-0 bg-brand" />
+      <div className="flex-1 min-w-0">
+        {editing ? (
+          <input
+            ref={inputRef}
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            onClick={(e) => e.stopPropagation()}
+            maxLength={200}
+            className="w-full text-[13px] leading-tight font-medium text-text-primary bg-bg-surface border border-brand rounded px-1.5 py-0.5 outline-none"
+            aria-label="대화 제목 편집"
+          />
+        ) : (
+          <p className={cn(
+            'text-[13px] leading-tight truncate',
+            isActive ? 'font-semibold text-brand' : 'font-medium text-text-primary',
+          )}>
+            {session.title}
+          </p>
+        )}
+        <p className="text-[11px] text-text-muted mt-1">
+          {formatDate(session.updatedAt)}
+        </p>
+      </div>
+      {editing ? (
+        <button
+          onMouseDown={(e) => { e.preventDefault(); e.stopPropagation(); void commit(); }}
+          className="w-6 h-6 rounded-md flex items-center justify-center text-brand hover:bg-brand-subtle transition-colors cursor-pointer shrink-0 mt-0.5"
+          aria-label="제목 저장"
+        >
+          <Check size={12} />
+        </button>
+      ) : (
+        <div className="flex items-center gap-0.5 shrink-0 mt-0.5">
+          <button
+            onClick={(e) => { e.stopPropagation(); setEditing(true); }}
+            className="opacity-0 group-hover:opacity-100 w-6 h-6 rounded-md flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-all cursor-pointer"
+            aria-label="대화 제목 편집"
+          >
+            <Pencil size={12} />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); onDelete(session.id); }}
+            className="opacity-0 group-hover:opacity-100 w-6 h-6 rounded-md flex items-center justify-center text-text-muted hover:text-[#DC2626] hover:bg-[#FEF2F2] transition-all cursor-pointer"
+            aria-label="대화 삭제"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/ItineraryCard.tsx
+++ b/src/components/chat/ItineraryCard.tsx
@@ -1,7 +1,7 @@
 import { Clock, Star, MapPin, Footprints, Train, Bus, Car } from 'lucide-react';
 import type { Itinerary, TransportMode, Place } from '@/types';
 import { CATEGORY_CONFIG } from '@/lib/utils';
-import { useCalendarStore } from '@/stores/calendarStore';
+import { useChatStore } from '@/stores/chatStore';
 import { useMapStore } from '@/stores/mapStore';
 import placesData from '@/mocks/places.json';
 
@@ -21,8 +21,9 @@ const TRANSPORT_LABEL: Record<TransportMode, string> = {
   taxi: '택시',
 };
 
-export default function ItineraryCard({ itinerary }: { itinerary: Itinerary }) {
-  const addEvent = useCalendarStore((s) => s.addEvent);
+export default function ItineraryCard({ itinerary, hideActions = false }: { itinerary: Itinerary; hideActions?: boolean }) {
+  const sendMessage = useChatStore((s) => s.sendMessage);
+  const isLoading = useChatStore((s) => s.isLoading);
   const startNavigation = useMapStore((s) => s.startNavigation);
 
   return (
@@ -138,21 +139,27 @@ export default function ItineraryCard({ itinerary }: { itinerary: Itinerary }) {
         })}
       </div>
 
-      {/* Actions */}
-      <div className="flex border-t border-border">
-        <button
-          onClick={() => startNavigation(itinerary)}
-          className="flex-1 py-2.5 text-[12px] font-medium text-brand hover:bg-brand-subtle transition-colors cursor-pointer border-r border-border"
-        >
-          경로 보기
-        </button>
-        <button
-          onClick={() => addEvent(itinerary)}
-          className="flex-1 py-2.5 text-[12px] font-medium text-brand hover:bg-brand-subtle transition-colors cursor-pointer"
-        >
-          일정 추가
-        </button>
-      </div>
+      {/* Actions — shared 페이지 같은 read-only 컨텍스트에선 숨김 */}
+      {!hideActions && (
+        <div className="flex border-t border-border">
+          <button
+            onClick={() => startNavigation(itinerary)}
+            className="flex-1 py-2.5 text-[12px] font-medium text-brand hover:bg-brand-subtle transition-colors cursor-pointer border-r border-border"
+          >
+            경로 보기
+          </button>
+          <button
+            onClick={() => {
+              if (isLoading) return;
+              void sendMessage(`"${itinerary.title}" 코스를 내 캘린더에 추가해줘`);
+            }}
+            disabled={isLoading}
+            className="flex-1 py-2.5 text-[12px] font-medium text-brand hover:bg-brand-subtle transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            일정 추가
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/chat/ShareButton.tsx
+++ b/src/components/chat/ShareButton.tsx
@@ -1,7 +1,8 @@
 // 채팅 공유 버튼 — 클릭 시 share_token 발급 + URL 클립보드 복사.
+// 공유 후엔 "취소" 보조 액션 노출.
 
 import { useState } from 'react';
-import { Share2, Check } from 'lucide-react';
+import { Share2, Check, X } from 'lucide-react';
 import { chatsApi } from '@/lib/api';
 import { friendlyApiError } from '@/lib/auth-errors';
 import { toast } from '@/stores/toastStore';
@@ -33,16 +34,21 @@ export default function ShareButton({ threadId }: Props) {
   const [copied, setCopied] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // 한 번이라도 공유했으면 "취소" 보조 액션 노출. 페이지 이탈 시 리셋(데모용 충분).
+  const [wasShared, setWasShared] = useState(false);
 
-  const onClick = async () => {
+  const onShare = async () => {
     if (busy) return;
     setBusy(true);
     setError(null);
     try {
       const res = await chatsApi.share(threadId, {});
-      const url = res.share_url.startsWith('http')
-        ? res.share_url
-        : `${window.location.origin}${res.share_url}`;
+      // BE는 share_url을 "/shared/{token}"로 발급하지만 vite/vercel rewrite가 BE API로 잡아채감.
+      // FE 라우트는 /s/{token}이므로 사용자에게 보여줄 URL은 그 형태로 치환.
+      const fePath = res.share_url.replace(/^\/shared\//, '/s/');
+      const url = fePath.startsWith('http')
+        ? fePath
+        : `${window.location.origin}${fePath}`;
       const ok = await copyOrPrompt(url);
       if (ok) {
         setCopied(true);
@@ -51,6 +57,7 @@ export default function ShareButton({ threadId }: Props) {
       } else {
         toast.info('클립보드 권한이 없어 prompt로 표시했어요');
       }
+      setWasShared(true);
     } catch (e) {
       const msg = friendlyApiError(e, '공유 링크 생성에 실패했습니다');
       setError(msg);
@@ -60,17 +67,49 @@ export default function ShareButton({ threadId }: Props) {
     }
   };
 
+  const onRevoke = async () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await chatsApi.revokeShare(threadId);
+      setWasShared(false);
+      toast.success('공유를 취소했어요');
+    } catch (e) {
+      const msg = friendlyApiError(e, '공유 취소에 실패했습니다');
+      setError(msg);
+      toast.error(msg);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={busy}
-      title={error ?? '공유 링크 복사'}
-      aria-label="공유 링크 복사"
-      className="inline-flex items-center gap-1.5 text-xs text-text-secondary hover:text-text-primary px-2 py-1 rounded hover:bg-bg-overlay transition-colors"
-    >
-      {copied ? <Check size={14} /> : <Share2 size={14} />}
-      <span>{copied ? '링크 복사됨' : '공유'}</span>
-    </button>
+    <div className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        onClick={onShare}
+        disabled={busy}
+        title={error ?? '공유 링크 복사'}
+        aria-label="공유 링크 복사"
+        className="inline-flex items-center gap-1.5 text-xs text-text-secondary hover:text-text-primary px-2 py-1 rounded hover:bg-bg-overlay transition-colors disabled:opacity-50"
+      >
+        {copied ? <Check size={14} /> : <Share2 size={14} />}
+        <span>{copied ? '링크 복사됨' : '공유'}</span>
+      </button>
+      {wasShared && (
+        <button
+          type="button"
+          onClick={onRevoke}
+          disabled={busy}
+          title="공유 취소"
+          aria-label="공유 취소"
+          className="inline-flex items-center gap-1 text-xs text-text-muted hover:text-[#DC2626] px-1.5 py-1 rounded hover:bg-[#FEF2F2] transition-colors disabled:opacity-50"
+        >
+          <X size={13} />
+          <span>취소</span>
+        </button>
+      )}
+    </div>
   );
 }

--- a/src/components/share/SharedPage.tsx
+++ b/src/components/share/SharedPage.tsx
@@ -2,7 +2,15 @@ import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { sharedApi } from '@/lib/api';
 import { friendlyApiError } from '@/lib/auth-errors';
-import type { SharedConversation } from '@/types/api';
+import type { Block, SharedConversation } from '@/types/api';
+import { BlockRenderer } from '@/components/chat/blocks';
+import PlaceCarousel from '@/components/chat/PlaceCarousel';
+import ItineraryCard from '@/components/chat/ItineraryCard';
+import {
+  singlePlaceBlockToPlace,
+  placesBlockToPlaces,
+  courseBlockToItinerary,
+} from '@/stores/chatStore';
 
 export default function SharedPage() {
   const { token } = useParams<{ token: string }>();
@@ -82,29 +90,71 @@ export default function SharedPage() {
 
 function SharedMessage({ role, blocks, createdAt }: { role: string; blocks: unknown[]; createdAt: string }) {
   const isUser = role === 'user';
-  const text = blocks
+  const time = new Date(createdAt).toLocaleString('ko-KR');
+  const typedBlocks = blocks as Block[];
+
+  // 텍스트 블록들은 모아서 하나의 버블로 (chat UI와 동일 패턴).
+  const text = typedBlocks
     .map((b) => {
-      const block = b as { type?: string; content?: string; delta?: string; text?: string };
-      if (block.type === 'text' || block.type === 'text_stream') {
-        return block.content ?? block.delta ?? block.text ?? '';
-      }
+      if (b.type === 'text') return b.content;
+      if (b.type === 'text_stream') return b.delta ?? b.content ?? '';
       return '';
     })
     .filter(Boolean)
-    .join(' ');
-  const time = new Date(createdAt).toLocaleString('ko-KR');
+    .join('');
+
+  // 구조화 블록 — 카드/카루셀로 별도 렌더. intent/done/error 같은 제어 프레임 skip.
+  // map_markers/map_route는 shared에 지도가 없어서 skip.
+  const structuredBlocks = typedBlocks.filter(
+    (b) =>
+      b.type !== 'text' &&
+      b.type !== 'text_stream' &&
+      b.type !== 'intent' &&
+      b.type !== 'status' &&
+      b.type !== 'done' &&
+      b.type !== 'done_partial' &&
+      b.type !== 'error' &&
+      b.type !== 'map_markers' &&
+      b.type !== 'map_route',
+  );
 
   return (
-    <div className={isUser ? 'self-end max-w-[85%]' : 'self-start max-w-[90%]'}>
-      <div
-        className={
-          isUser
-            ? 'bg-brand-subtle border border-brand rounded-2xl rounded-br-md px-4 py-2.5 text-sm'
-            : 'bg-bg-warm border border-border rounded-2xl rounded-bl-md px-4 py-2.5 text-sm'
-        }
-      >
-        {text || <span className="text-text-muted">[멀티미디어 응답]</span>}
-      </div>
+    <div className={isUser ? 'self-end max-w-[85%]' : 'self-start w-full max-w-full'}>
+      {text && (
+        <div
+          className={
+            isUser
+              ? 'bg-brand-subtle border border-brand rounded-2xl rounded-br-md px-4 py-2.5 text-sm whitespace-pre-wrap'
+              : 'bg-bg-warm border border-border rounded-2xl rounded-bl-md px-4 py-2.5 text-sm whitespace-pre-wrap leading-[1.6]'
+          }
+        >
+          {text}
+        </div>
+      )}
+
+      {!isUser && structuredBlocks.length > 0 && (
+        <div className="flex flex-col gap-2.5 mt-2.5">
+          {structuredBlocks.map((b, i) => {
+            if (b.type === 'place') {
+              return <PlaceCarousel key={i} places={[singlePlaceBlockToPlace(b)]} />;
+            }
+            if (b.type === 'places') {
+              return <PlaceCarousel key={i} places={placesBlockToPlaces(b)} />;
+            }
+            if (b.type === 'course') {
+              return <ItineraryCard key={i} itinerary={courseBlockToItinerary(b)} hideActions />;
+            }
+            return <BlockRenderer key={i} block={b} />;
+          })}
+        </div>
+      )}
+
+      {!text && structuredBlocks.length === 0 && (
+        <div className="bg-bg-warm border border-border rounded-2xl px-4 py-2.5 text-sm text-text-muted">
+          [내용 없음]
+        </div>
+      )}
+
       <div className="text-[10px] text-text-muted mt-1 px-2">{time}</div>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -61,7 +61,8 @@ function Bootstrap() {
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
-          <Route path="/shared/:token" element={<SharedPage />} />
+          {/* /shared/:token은 BE API와 충돌(vite/vercel rewrite 잡힘) — FE 라우트는 /s/:token. */}
+          <Route path="/s/:token" element={<SharedPage />} />
           <Route path="/calendar/connected" element={<CalendarConnected />} />
           <Route
             path="/settings"

--- a/src/stores/bookmarkStore.ts
+++ b/src/stores/bookmarkStore.ts
@@ -83,6 +83,7 @@ function bookmarkItemToMessage(item: BookmarkItem): MessageBookmarkItem {
     bookmarkId: String(item.bookmark_id),
     messageId: String(item.message_id),
     conversationId: item.thread_id,
+    pinType: item.pin_type,
     snapshot: {
       role: 'assistant',
       createdAt: item.created_at,
@@ -198,6 +199,7 @@ export const useBookmarkStore = create<BookmarkStore>((set, get) => ({
       bookmarkId: tempId,
       messageId,
       conversationId,
+      pinType: pinTypeFromSnapshot(snapshot),
       snapshot,
       createdAt: new Date().toISOString(),
     };

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -10,7 +10,7 @@ import { useMapStore } from './mapStore';
 
 // SSE 블록 → 레거시 Message 타입 어댑터.
 
-function singlePlaceBlockToPlace(it: PlaceBlockData): Place {
+export function singlePlaceBlockToPlace(it: PlaceBlockData): Place {
   // BE PlaceBlock.congestion (PR #70 머지 시 자동 활성화). snake_case → camelCase 변환.
   // mock 시절 camelCase updatedAt 폴백 흡수 — 양쪽 데이터 지원.
   const c = it.congestion as
@@ -34,7 +34,7 @@ function singlePlaceBlockToPlace(it: PlaceBlockData): Place {
   };
 }
 
-function placesBlockToPlaces(block: PlacesBlock): Place[] {
+export function placesBlockToPlaces(block: PlacesBlock): Place[] {
   return block.items.map((it) => singlePlaceBlockToPlace({ ...it, type: 'place' }));
 }
 
@@ -59,7 +59,7 @@ function eventsBlockToPlaces(block: EventsBlock): Place[] {
     }));
 }
 
-function courseBlockToItinerary(block: CourseBlock): Itinerary {
+export function courseBlockToItinerary(block: CourseBlock): Itinerary {
   // BE CourseBlock 실제 스키마: stop이 nested(place/transit_to_next). arrival_time/transit는 BE 값을 우선,
   // 누락 시 누적 커서로 보정.
   let cursor = 10 * 60; // 10:00 fallback start

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -126,10 +126,14 @@ export interface MessageSnapshot {
   itinerary?: Itinerary | null;
 }
 
+// PinType은 BE bookmarks 모델과 동일 (api.ts 재export 회피 — 순환 import 방지).
+export type BookmarkPinType = 'place' | 'event' | 'course' | 'analysis' | 'general';
+
 export interface MessageBookmarkItem {
   bookmarkId: string;
   messageId: string;
   conversationId: string;
+  pinType: BookmarkPinType;
   snapshot: MessageSnapshot;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary

FE_TODO_2026-05-15.md 4개 항목 대응 + 공유 페이지 URL 충돌 픽스 + 북마크 핀 타입 칩 + BE 요청 docs 정리.

### 사이드바 대화 제목 변경 (TODO #1)
- `SessionItem` 서브컴포넌트 분리, Pencil 아이콘 hover-revealed
- 인라인 input, Enter/blur 저장, Escape 취소, 200자 limit

### 코스 일정 추가 BE 연동 (TODO #3)
- 로컬 calendarStore 저장 → `sendMessage`로 BE CALENDAR intent 트리거
- BE가 Google Calendar API 실제 호출, calendar 블록 응답

### 공유 페이지 (TODO #2)
- ShareButton에 공유 취소 보조 액션 추가 (X 아이콘)
- **URL 충돌 픽스**: `/shared/:token`이 vite/vercel rewrite에 잡혀 BE로 직행하던 버그
  → FE 라우트 `/s/:token`으로 분리, share_url 치환
- **카드 풍부 렌더**: SharedPage가 BlockRenderer + PlaceCarousel + ItineraryCard 직접 사용
  → 장소/코스/이벤트/캘린더/차트 다 표시 (이전엔 텍스트만 보임)
- ItineraryCard `hideActions` prop 추가 (read-only context)

### 대화 북마크 pin_type 칩
- BE의 pin_type을 FE에 플럼빙 (`MessageBookmarkItem.pinType`)
- BookmarkPanel 카드 좌상단에 핀 타입별 칩
  - 장소(navy), 행사(orange), 코스(green), 분석(gray), general은 숨김

### TODO #4 행사 링크
이미 동작 중 (`homepage_url` 매핑). 추가 작업 없음.

### docs
- `docs/be-requests.md`에 #9 (북마크 422), #10 (장소 북마크 API), #11 (캘린더 callback redirect) 추가
- #1, #3 Resolved로 갱신 (BE 작업 완료 확인)

## Test plan
- [ ] 사이드바 세션 hover → Pencil → 클릭 → 인라인 편집 → Enter 저장
- [ ] 코스 카드 "일정 추가" → 채팅에 "코스를 내 캘린더에 추가해줘" 메시지 전송 → BE 응답
- [ ] 채팅 ShareButton 클릭 → URL 복사 → 옆에 "취소" 버튼 등장
- [ ] 공유 URL을 새 탭에서 열기 → JSON 아닌 정상 페이지, 장소 카드/코스/이벤트 표시
- [ ] 다양한 인텐트 메시지 북마크 → 핀 타입별 칩 색상 구분

🤖 Generated with [Claude Code](https://claude.com/claude-code)