### PR TITLE
feat: SSE done.message_id 반영 — 새로고침 없이 북마크/피드백/공유 활성

### DIFF
--- a/src/stores/apiChatStore.ts
+++ b/src/stores/apiChatStore.ts
@@ -183,6 +183,12 @@ export const useApiChatStore = create<ApiChatStore>((set, get) => ({
       done: (data) => {
         // rAF 큐에 남은 delta가 있으면 done 처리 전 동기 flush.
         flushStreamSync(set);
+        // BE PR #81 — done.message_id 가 있으면 임시 로컬 ID를 BE id로 교체.
+        // loadThread/mapMessageItem 경로(`id: String(item.message_id)`)와 정합.
+        const beId =
+          data.type === 'done' && typeof data.message_id === 'number'
+            ? String(data.message_id)
+            : null;
         set((s) => ({
           isStreaming: false,
           currentStatus: '',
@@ -193,7 +199,7 @@ export const useApiChatStore = create<ApiChatStore>((set, get) => ({
               finalBlocks.push({ type: 'text', content: m.streamingText });
             }
             finalBlocks.push(data);
-            return { ...m, done: true, blocks: finalBlocks };
+            return { ...m, id: beId ?? m.id, done: true, blocks: finalBlocks };
           }),
           _connection: null,
         }));

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -245,6 +245,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     let itinerary: Itinerary | undefined;
     const itineraries: Itinerary[] = [];
     const otherBlocks: Block[] = [];
+    // BE PR #81 — done 이벤트에서 송신되는 assistant message_id 캡처.
+    // 새로고침 없이 북마크/피드백/공유 버튼 동작에 필요.
+    let beMessageId: number | undefined;
 
     await new Promise<void>((resolve) => {
       const conn = openChatStream(sessionId, text, {
@@ -290,7 +293,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         map_route: (data) => otherBlocks.push(data),
         intent: () => {},
         status: () => {},
-        done: () => {
+        done: (data) => {
+          if (data.type === 'done' && typeof data.message_id === 'number') {
+            beMessageId = data.message_id;
+          }
           conn.close();
           resolve();
         },
@@ -319,7 +325,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       itineraries: itineraries.length > 1 ? itineraries : undefined,
       blocks: otherBlocks.length > 0 ? otherBlocks : undefined,
       threadId: sessionId,
-      messageId: agentId,
+      // BE 송신 message_id 우선, 없으면 FE 로컬 ID(fallback — 북마크/피드백 비활성).
+      messageId: beMessageId ?? agentId,
     };
 
     if (places && places.length > 0) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -314,6 +314,9 @@ export type DoneBlock = {
   reason?: string;
   partial?: boolean;
   error_message?: string;
+  // BE PR #81 — done 시점에 DB에 저장된 assistant message_id.
+  // 북마크/피드백/공유 버튼이 새로고침 없이 즉시 사용 가능하도록 활용.
+  message_id?: number;
 };
 
 export type ErrorBlock = {


### PR DESCRIPTION
## 작업 내용

BE PR #81 에서 SSE `done` 이벤트에 `message_id` 필드가 추가됐는데 FE 가 무시하던 문제 해결.

### 변경 파일
- `src/types/api.ts` — `DoneBlock` 에 `message_id?: number` 추가
- `src/stores/chatStore.ts` (active) — `done` 핸들러에서 `message_id` 캡처 → `agentMsg.messageId` 로 사용. 누락 시 로컬 ID fallback.
- `src/stores/apiChatStore.ts` (parallel store) — `done` 시 BE id 로 메시지 `id` 교체. `loadThread/mapMessageItem` 의 `id: String(item.message_id)` 컨벤션과 정합.

### 효과
어시스턴트 메시지를 받은 직후 `MessageBubble.tsx:99` 의 가드:
```ts
message.messageId != null && String(message.messageId).length > 0
```
를 통과 → **북마크/피드백/공유 버튼이 새로고침 없이 즉시 노출**.

기존: 메시지 받자마자 버튼 안 보이고, 페이지 새로고침 후 BE 메시지 리스트 동기화 되어야 보이던 상태.

## 체크리스트
- [x] typecheck 0 errors
- [x] 기존 13/13 tests pass
- [x] BE/FE 양쪽 store 모두 반영

## 관련
BE PR #81 (done 이벤트 message_id 필드 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)