### PR TITLE
feat: 장소 북마크 BE 연동 — /users/me/place-bookmarks

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,9 @@ import type {
   BookmarkCreateRequest,
   BookmarkCreateResponse,
   BookmarkListResponse,
+  PlaceBookmarkCreateRequest,
+  PlaceBookmarkItem,
+  PlaceBookmarkListResponse,
   ChatDetailResponse,
   ChatListResponse,
   FeedbackRequest,
@@ -259,6 +262,19 @@ export const bookmarksApi = {
     request<BookmarkListResponse>(buildUrl('/api/v1/users/me/bookmarks', params)),
   delete: (bookmark_id: string | number) =>
     request<void>(`/api/v1/users/me/bookmarks/${encodeURIComponent(String(bookmark_id))}`, { method: 'DELETE' }),
+};
+
+// 장소 북마크 — BE PR #80 (3 endpoints, soft delete, idempotent upsert).
+export const placeBookmarksApi = {
+  list: (params?: { cursor?: string; limit?: number }) =>
+    request<PlaceBookmarkListResponse>(buildUrl('/api/v1/users/me/place-bookmarks', params)),
+  create: (body: PlaceBookmarkCreateRequest) =>
+    request<PlaceBookmarkItem>('/api/v1/users/me/place-bookmarks', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  delete: (bookmark_id: number) =>
+    request<void>(`/api/v1/users/me/place-bookmarks/${bookmark_id}`, { method: 'DELETE' }),
 };
 
 export const chatsApi = {

--- a/src/stores/bookmarkStore.ts
+++ b/src/stores/bookmarkStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import type { Place, MessageBookmarkItem, MessageSnapshot } from '@/types';
-import type { BookmarkItem, PinType } from '@/types/api';
-import { bookmarksApi } from '@/lib/api';
+import type { BookmarkItem, PinType, PlaceBookmarkItem } from '@/types/api';
+import { bookmarksApi, placeBookmarksApi } from '@/lib/api';
 import { friendlyApiError } from '@/lib/auth-errors';
 import placesData from '@/mocks/places.json';
 
@@ -9,6 +9,7 @@ const allPlaces = placesData as Place[];
 
 const PLACE_STORAGE_KEY = 'seoul-ai-bookmarks';
 const PLACE_SNAPSHOT_STORAGE_KEY = 'seoul-ai-bookmark-snapshots';
+const PLACE_BOOKMARK_ID_KEY = 'seoul-ai-place-bookmark-ids';
 const MSG_STORAGE_KEY = 'seoul-ai-message-bookmarks';
 // prod에선 빈 상태로 시작. dev에선 mock 4개 시드해서 UI 검수 편의.
 const DEFAULT_PLACE_IDS: string[] = import.meta.env.DEV
@@ -67,6 +68,55 @@ function saveMessageItems(items: MessageBookmarkItem[]) {
   } catch { /* ignore */ }
 }
 
+// place_id → BE bookmark_id 매핑. DELETE 호출 시 필요.
+function loadPlaceBookmarkIds(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(PLACE_BOOKMARK_ID_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object') return parsed as Record<string, number>;
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function savePlaceBookmarkIds(map: Record<string, number>) {
+  try {
+    localStorage.setItem(PLACE_BOOKMARK_ID_KEY, JSON.stringify(map));
+  } catch { /* ignore */ }
+}
+
+function placeToCreateRequest(place: Place) {
+  return {
+    place_id: place.id,
+    name: place.name,
+    category: place.category ?? null,
+    address: place.address || null,
+    lat: typeof place.lat === 'number' && place.lat !== 0 ? place.lat : null,
+    lng: typeof place.lng === 'number' && place.lng !== 0 ? place.lng : null,
+    rating: typeof place.rating === 'number' && place.rating > 0 ? place.rating : null,
+    image_url: place.image ?? null,
+    summary: place.summary || null,
+  };
+}
+
+function placeBookmarkItemToPlace(item: PlaceBookmarkItem): Place {
+  return {
+    id: item.place_id,
+    name: item.name,
+    // BE 카테고리가 임의 문자열이라 안전한 fallback.
+    category: (item.category as Place['category']) ?? 'tourism',
+    address: item.address ?? '',
+    lat: item.lat ?? 0,
+    lng: item.lng ?? 0,
+    hours: '',
+    rating: item.rating ?? 0,
+    summary: item.summary ?? '',
+    image: item.image_url ?? undefined,
+  };
+}
+
 interface ToggleMessageInput {
   messageId: string;
   conversationId: string;
@@ -101,10 +151,12 @@ const TEMP_BOOKMARK_PREFIX = 'temp-mb-';
 const isTempBookmark = (id: string): boolean => id.startsWith(TEMP_BOOKMARK_PREFIX);
 
 interface BookmarkStore {
-  // Place bookmarks (localStorage only — phase 3에선 BE 통합 보류)
+  // Place bookmarks — BE PR #80 동기화 (optimistic + offline localStorage 캐시).
   bookmarkedIds: string[];
   // SSE-driven 장소(places.json에 없는)도 카드에 노출되도록 스냅샷 보관.
   placeSnapshots: Record<string, Place>;
+  // place_id → BE bookmark_id. DELETE 호출에 필요. 매핑 없으면 BE 호출 skip.
+  placeBookmarkIds: Record<string, number>;
   // toggle에 Place를 넘기면 스냅샷 같이 저장 (권장). string 단독 호출은 레거시 호환.
   toggle: (input: string | Place) => void;
   add: (id: string) => void;
@@ -136,6 +188,7 @@ export const useBookmarkStore = create<BookmarkStore>((set, get) => ({
       ? purgeStaleIds(loadPlaceIds(), loadPlaceSnapshots())
       : DEFAULT_PLACE_IDS,
   placeSnapshots: typeof window !== 'undefined' ? loadPlaceSnapshots() : {},
+  placeBookmarkIds: typeof window !== 'undefined' ? loadPlaceBookmarkIds() : {},
   messageItems: typeof window !== 'undefined' ? loadMessageItems() : [],
   messageBookmarksLoading: false,
   messageBookmarksError: null,
@@ -143,8 +196,10 @@ export const useBookmarkStore = create<BookmarkStore>((set, get) => ({
   toggle: (input) => {
     const place = typeof input === 'string' ? null : input;
     const id = place ? place.id : input as string;
-    const { bookmarkedIds, placeSnapshots } = get();
+    const { bookmarkedIds, placeSnapshots, placeBookmarkIds } = get();
     const isAdded = !bookmarkedIds.includes(id);
+
+    // Optimistic 로컬 업데이트.
     const nextIds = isAdded
       ? [...bookmarkedIds, id]
       : bookmarkedIds.filter((x) => x !== id);
@@ -157,24 +212,68 @@ export const useBookmarkStore = create<BookmarkStore>((set, get) => ({
     savePlaceIds(nextIds);
     savePlaceSnapshots(nextSnapshots);
     set({ bookmarkedIds: nextIds, placeSnapshots: nextSnapshots });
+
+    // BE 동기화 — 실패해도 다음 loadFromServer에서 진실 복원.
+    if (isAdded) {
+      // 추가: snapshot이 있으면 BE에 보내고 bookmark_id 회수.
+      const snap = place ?? placeSnapshots[id];
+      if (!snap) return; // 정보 부족 — BE 호출 skip.
+      placeBookmarksApi
+        .create(placeToCreateRequest(snap))
+        .then((res) => {
+          const updated = { ...get().placeBookmarkIds, [id]: res.bookmark_id };
+          savePlaceBookmarkIds(updated);
+          set({ placeBookmarkIds: updated });
+        })
+        .catch(() => { /* silent — 다음 loadFromServer 복원 */ });
+    } else {
+      // 삭제: 매핑이 있을 때만 BE DELETE.
+      const bookmarkId = placeBookmarkIds[id];
+      if (bookmarkId == null) return;
+      const nextMap = { ...placeBookmarkIds };
+      delete nextMap[id];
+      savePlaceBookmarkIds(nextMap);
+      set({ placeBookmarkIds: nextMap });
+      placeBookmarksApi.delete(bookmarkId).catch(() => { /* silent */ });
+    }
   },
 
   add: (id) => {
-    const { bookmarkedIds } = get();
+    const { bookmarkedIds, placeSnapshots } = get();
     if (bookmarkedIds.includes(id)) return;
     const next = [...bookmarkedIds, id];
     savePlaceIds(next);
     set({ bookmarkedIds: next });
+    // BE 동기화 — snapshot이 있는 경우만 정확한 정보 전송 가능.
+    const snap = placeSnapshots[id];
+    if (snap) {
+      placeBookmarksApi
+        .create(placeToCreateRequest(snap))
+        .then((res) => {
+          const updated = { ...get().placeBookmarkIds, [id]: res.bookmark_id };
+          savePlaceBookmarkIds(updated);
+          set({ placeBookmarkIds: updated });
+        })
+        .catch(() => { /* silent */ });
+    }
   },
 
   remove: (id) => {
-    const { bookmarkedIds, placeSnapshots } = get();
+    const { bookmarkedIds, placeSnapshots, placeBookmarkIds } = get();
     const next = bookmarkedIds.filter((x) => x !== id);
     const nextSnapshots = { ...placeSnapshots };
     delete nextSnapshots[id];
     savePlaceIds(next);
     savePlaceSnapshots(nextSnapshots);
     set({ bookmarkedIds: next, placeSnapshots: nextSnapshots });
+
+    const bookmarkId = placeBookmarkIds[id];
+    if (bookmarkId == null) return;
+    const nextMap = { ...placeBookmarkIds };
+    delete nextMap[id];
+    savePlaceBookmarkIds(nextMap);
+    set({ placeBookmarkIds: nextMap });
+    placeBookmarksApi.delete(bookmarkId).catch(() => { /* silent */ });
   },
 
   isBookmarked: (id) => get().bookmarkedIds.includes(id),
@@ -255,17 +354,44 @@ export const useBookmarkStore = create<BookmarkStore>((set, get) => ({
 
   loadFromServer: async () => {
     set({ messageBookmarksLoading: true, messageBookmarksError: null });
-    try {
-      const res = await bookmarksApi.list({ limit: 100 });
-      const items = res.items.map(bookmarkItemToMessage);
+    // 두 종류 북마크(메시지 + 장소) 병렬 fetch.
+    const [msgRes, placeRes] = await Promise.allSettled([
+      bookmarksApi.list({ limit: 100 }),
+      placeBookmarksApi.list({ limit: 100 }),
+    ]);
+
+    if (msgRes.status === 'fulfilled') {
+      const items = msgRes.value.items.map(bookmarkItemToMessage);
       saveMessageItems(items);
-      set({ messageItems: items, messageBookmarksLoading: false });
-    } catch (e) {
-      // 비로그인 / 네트워크 실패 — 로컬 유지하되 오류 메시지는 노출.
+      set({ messageItems: items });
+    }
+
+    if (placeRes.status === 'fulfilled') {
+      // BE = 진실. localStorage 캐시를 덮어쓴다.
+      const items = placeRes.value.items;
+      const ids = items.map((it) => it.place_id);
+      const snapshots: Record<string, Place> = {};
+      const idMap: Record<string, number> = {};
+      for (const it of items) {
+        snapshots[it.place_id] = placeBookmarkItemToPlace(it);
+        idMap[it.place_id] = it.bookmark_id;
+      }
+      savePlaceIds(ids);
+      savePlaceSnapshots(snapshots);
+      savePlaceBookmarkIds(idMap);
+      set({ bookmarkedIds: ids, placeSnapshots: snapshots, placeBookmarkIds: idMap });
+    }
+
+    if (msgRes.status === 'rejected') {
       set({
         messageBookmarksLoading: false,
-        messageBookmarksError: friendlyApiError(e, '북마크를 불러올 수 없습니다'),
+        messageBookmarksError: friendlyApiError(
+          msgRes.reason,
+          '북마크를 불러올 수 없습니다',
+        ),
       });
+    } else {
+      set({ messageBookmarksLoading: false });
     }
   },
 }));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -54,6 +54,44 @@ export type BookmarkCreateResponse = {
   created_at: string;
 };
 
+// === Place Bookmarks (BE PR #80 — Phase 2) ===
+export type PlaceBookmarkCreateRequest = {
+  place_id: string;
+  name: string;
+  category?: string | null;
+  address?: string | null;
+  district?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+  rating?: number | null;
+  image_url?: string | null;
+  summary?: string | null;
+  source_thread_id?: string | null;
+  source_message_id?: number | null;
+};
+
+export type PlaceBookmarkItem = {
+  bookmark_id: number;
+  place_id: string;
+  name: string;
+  category?: string | null;
+  address?: string | null;
+  district?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+  rating?: number | null;
+  image_url?: string | null;
+  summary?: string | null;
+  source_thread_id?: string | null;
+  source_message_id?: number | null;
+  created_at: string;
+};
+
+export type PlaceBookmarkListResponse = {
+  items: PlaceBookmarkItem[];
+  next_cursor: string | null;
+};
+
 // === Chats ===
 export type ChatListItem = {
   thread_id: string;


### PR DESCRIPTION
## 작업 내용

BE PR #80 (#102 머지) 의 장소 북마크 3 엔드포인트와 FE 연동.
기존엔 PlaceCard 의 ☆ 버튼이 브라우저 localStorage 에만 저장돼 다른 기기에서 안 보였는데, 이제 BE 와 동기화됩니다.

### 변경 파일
- `src/types/api.ts` — `PlaceBookmarkItem` / `PlaceBookmarkCreateRequest` / `PlaceBookmarkListResponse` 타입
- `src/lib/api.ts` — `placeBookmarksApi.{list, create, delete}`
- `src/stores/bookmarkStore.ts`:
  - `placeBookmarkIds: Record<place_id, bookmark_id>` 매핑 신설 + localStorage 캐시
  - `toggle/add/remove`: 로컬 optimistic + BE 동기화 (fire-and-forget). 실패는 silent, 다음 `loadFromServer` 에서 진실 복원
  - `loadFromServer`: 메시지/장소 북마크 `Promise.allSettled` 로 병렬 fetch. BE 응답을 진실로 받아 캐시 덮어쓰기
  - `placeToCreateRequest` / `placeBookmarkItemToPlace` 양방향 변환 helper

### 동작 흐름
1. 로그인 → App.tsx `useEffect` 가 `loadFromServer` 호출 → 메시지/장소 북마크 둘 다 fetch
2. PlaceCard 의 ☆ 클릭 → `toggle(place)` → 즉시 UI 반영 + BE POST → 응답의 bookmark_id 를 매핑 저장
3. ☆ 해제 → 매핑에서 bookmark_id 조회 → BE DELETE (소프트 삭제)
4. 새로고침/다른 기기 로그인 → 1번부터 다시

### 호환성
- `toggle(place)` / `add(id)` / `remove(id)` 시그니처 그대로 (void 반환). BE 호출은 fire-and-forget
- PlaceCard, PlaceCarousel, PlaceOverlayItem, BookmarkPanel 모든 사용처 수정 0

## 체크리스트
- [x] AGENTS.md 스키마 준수
- [x] typecheck 0 errors
- [x] 기존 13/13 tests pass
- [x] 비로그인/네트워크 실패 시 silent 로 동작 (로컬 캐시 fallback)

## 관련
- BE PR #80 (`Techeer-2026-1/LocalBiz-Seoul#102` 머지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)