### PR TITLE
chore: 온보딩 관심사 선택 단계 제거

### DIFF
--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -1,45 +1,22 @@
-
-
 import { useEffect, useState } from 'react';
-import { MapPin, ShoppingBag, Palette, UtensilsCrossed, Moon, Music, ArrowRight } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { ArrowRight } from 'lucide-react';
 import LottiePlayer from '@/components/ui/LottiePlayer';
 
 interface OnboardingFlowProps {
-  onComplete: (interests: string[]) => void;
+  onComplete: () => void;
 }
 
-const INTERESTS = [
-  { key: 'tourism', label: '관광 명소', icon: MapPin },
-  { key: 'shopping', label: '쇼핑', icon: ShoppingBag },
-  { key: 'culture', label: '문화 체험', icon: Palette },
-  { key: 'food', label: '음식 / 맛집', icon: UtensilsCrossed },
-  { key: 'nightlife', label: '야경 / 카페', icon: Moon },
-  { key: 'entertainment', label: '엔터테인먼트', icon: Music },
-];
-
-type Step = 'splash' | 'interests' | 'success';
+type Step = 'splash' | 'success';
 
 export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
   const [step, setStep] = useState<Step>('splash');
-  const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
-
-  const toggleInterest = (key: string) => {
-    setSelectedInterests((prev) =>
-      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
-    );
-  };
-
-  const handleFinish = () => {
-    setStep('success');
-  };
 
   // Auto-dismiss the success celebration after the Lottie has time to play
   useEffect(() => {
     if (step !== 'success') return;
-    const t = setTimeout(() => onComplete(selectedInterests), 1600);
+    const t = setTimeout(onComplete, 1600);
     return () => clearTimeout(t);
-  }, [step, onComplete, selectedInterests]);
+  }, [step, onComplete]);
 
   if (step === 'splash') {
     return (
@@ -60,7 +37,7 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
             AI 에이전트가 여행을 설계합니다.
           </p>
           <button
-            onClick={() => setStep('interests')}
+            onClick={() => setStep('success')}
             className="group inline-flex items-center gap-2 px-6 py-3 bg-text-primary text-text-inverse rounded-full text-[14px] font-medium transition-all duration-200 hover:shadow-lg active:scale-[0.98] cursor-pointer"
           >
             시작하기
@@ -71,75 +48,31 @@ export default function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
     );
   }
 
-  if (step === 'success') {
-    return (
-      <div className="h-full flex flex-col items-center justify-center p-8 bg-bg-base">
-        <div className="text-center animate-fade-up">
-          <LottiePlayer
-            src="/animations/success.json"
-            className="w-40 h-40 mx-auto mb-4"
-            loop={false}
-            ariaLabel="설정 완료"
-            fallback={
-              <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-brand-subtle flex items-center justify-center">
-                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
-                  <polyline points="20 6 9 17 4 12" />
-                </svg>
-              </div>
-            }
-          />
-          <h2
-            className="text-[24px] text-text-primary mb-2"
-            style={{ fontFamily: 'var(--font-display)', letterSpacing: '-0.02em' }}
-          >
-            모든 준비가 끝났어요
-          </h2>
-          <p className="text-[14px] text-text-secondary">
-            서울의 모든 순간을 함께할게요.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="h-full flex flex-col items-center justify-center p-8 bg-bg-base">
-      <div className="w-full max-w-sm animate-fade-up">
+      <div className="text-center animate-fade-up">
+        <LottiePlayer
+          src="/animations/success.json"
+          className="w-40 h-40 mx-auto mb-4"
+          loop={false}
+          ariaLabel="설정 완료"
+          fallback={
+            <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-brand-subtle flex items-center justify-center">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-brand">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            </div>
+          }
+        />
         <h2
-          className="text-[24px] text-text-primary text-center mb-8"
+          className="text-[24px] text-text-primary mb-2"
           style={{ fontFamily: 'var(--font-display)', letterSpacing: '-0.02em' }}
         >
-          어떤 경험을 찾고 있나요?
+          모든 준비가 끝났어요
         </h2>
-        <div className="grid grid-cols-2 gap-2.5 mb-8 stagger-children">
-          {INTERESTS.map((item) => {
-            const Icon = item.icon;
-            const isSelected = selectedInterests.includes(item.key);
-            return (
-              <button
-                key={item.key}
-                onClick={() => toggleInterest(item.key)}
-                className={cn(
-                  'flex items-center gap-2.5 p-3.5 rounded-xl border transition-all duration-200 cursor-pointer',
-                  isSelected
-                    ? 'border-brand bg-brand-subtle shadow-xs'
-                    : 'border-border bg-bg-surface hover:border-border-strong hover:shadow-xs',
-                )}
-              >
-                <Icon size={18} strokeWidth={1.5} className={isSelected ? 'text-brand' : 'text-text-muted'} />
-                <span className={cn('text-[13px] font-medium', isSelected ? 'text-brand' : 'text-text-secondary')}>
-                  {item.label}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-        <button
-          onClick={handleFinish}
-          className="w-full py-3 bg-text-primary text-text-inverse rounded-full text-[14px] font-medium transition-all duration-200 hover:shadow-lg active:scale-[0.98] cursor-pointer"
-        >
-          시작하기
-        </button>
+        <p className="text-[14px] text-text-secondary">
+          서울의 모든 순간을 함께할게요.
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## 작업 내용

온보딩 흐름의 두번째 단계(관심사 6개 그리드 선택)가 선택 결과를 어디에서도 사용하지 않는 의미 없는 단계라서 제거.

### Before / After
- Before: `splash → interests → success`
- After: `splash → success`

### 변경
- `OnboardingFlow.tsx`:
  - `Step` 타입에서 `'interests'` 제거
  - `INTERESTS` 상수, `selectedInterests` 상태, `toggleInterest` 함수, interests UI 블록 모두 제거
  - `onComplete` 시그니처: `(interests: string[]) => void` → `() => void`
  - 미사용 lucide 아이콘 import 6개(MapPin, ShoppingBag, Palette, UtensilsCrossed, Moon, Music) 제거
- `App.tsx` 무수정 — `handleOnboardingComplete` 가 이미 인자 없이 정의돼 있어 호환

### 검증
- typecheck 0 errors
- 기존 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)