### PR TITLE
perf: 3D 건물 로딩을 경로 stop 좌표 기반으로 한정 (미니멀)

### DIFF
--- a/src/components/map/ThreeMap.tsx
+++ b/src/components/map/ThreeMap.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useCallback } from 'react';
 import { MapScene3D } from '@/lib/three-scene';
-import { fetchBuildings, fetchBuildingsNearPoint } from '@/lib/overpass';
+import { fetchBuildingsNearPoint } from '@/lib/overpass';
 import type { Place } from '@/types';
 import { useMapStore } from '@/stores/mapStore';
 import type { NavigationState } from '@/stores/mapStore';
@@ -62,7 +62,9 @@ export default function ThreeMap({
     return () => ro.disconnect();
   }, []);
 
-  // Load buildings + tiles when center changes
+  // Load ground tiles + set center when camera target changes.
+  // 건물은 더 이상 viewport 단위로 받지 않는다 — 경로 추천 받은 stop 좌표 주변만
+  // navigation effect 에서 fetchBuildingsNearPoint 로 로드한다.
   const loadArea = useCallback(async () => {
     const scene = sceneRef.current;
     if (!scene) return;
@@ -84,22 +86,12 @@ export default function ThreeMap({
 
       // Set center first so markers render immediately
       scene.loadBuildings([], { lat: center.lat, lon: center.lng });
+      onBuildingCount(0);
 
-      // Load ground tiles + buildings in parallel
-      const [buildings] = await Promise.all([
-        fetchBuildings(bounds.south, bounds.west, bounds.north, bounds.east),
-        scene.loadGround(bounds, zoom),
-      ]);
+      await scene.loadGround(bounds, zoom);
 
-      // Ground is visible now — hide spinner
       onLoadingChange(false);
       scene.resetCamera();
-
-      // Add buildings (non-blocking visual enhancement)
-      if (buildings.length > 0) {
-        scene.loadBuildings(buildings, { lat: center.lat, lon: center.lng });
-        onBuildingCount(buildings.length);
-      }
     } catch (err) {
       onError(err instanceof Error ? err.message : '3D 로딩 실패');
       loadedCenterRef.current = '';
@@ -130,6 +122,9 @@ export default function ThreeMap({
 
     if (!navigation) {
       scene.clearRoute();
+      // 경로 해제 시 stop 주변에 띄워둔 건물도 함께 제거 (페이드 아웃).
+      scene.transitionBuildings([], { lat: center.lat, lon: center.lng });
+      onBuildingCount(0);
       prevNavRef.current = null;
       prevStopBuildingRef.current = -1;
       return;
@@ -166,7 +161,7 @@ export default function ThreeMap({
         });
       }
     }
-  }, [navId, navStopIndex, navigation, markers, onBuildingCount]);
+  }, [navId, navStopIndex, navigation, markers, onBuildingCount, center.lat, center.lng]);
 
   // Auto-play: advance stops when isPlaying (primitive deps)
   useEffect(() => {


### PR DESCRIPTION
## 작업 내용

3D 모드 건물 로딩 전략 변경. viewport 기반 → **경로 stop 좌표 주변만**.

### Before
- 3D 진입 시 viewport bounds(~1.5km 박스) 안의 모든 건물을 Overpass live fetch
- 사전 캐시(종로) 외 지역 = 외부 4개 미러 race + 10초 timeout, 실패 시 빈 채로 진행

### After
- 3D 진입 시 외부 Overpass 호출 **0** (마커 + ground 타일만)
- 경로 추천을 받아 navigation 이 활성화되면, 각 stop 좌표 반경 500m 만 `fetchBuildingsNearPoint` 로 로드 (기존 동작)
- 경로 해제 시 `transitionBuildings([])` 로 페이드 아웃

### 변경 파일
- `src/components/map/ThreeMap.tsx`
  - `loadArea()` 에서 `fetchBuildings(bounds...)` 호출 제거. ground 타일과 center 세팅만 남김
  - navigation 종료 시 빌딩 fade-out + `onBuildingCount(0)`
  - 미사용 `fetchBuildings` import 제거

### 효과
- 외부 Overpass 의존 거의 사라짐 (stop 단위로만 호출)
- 3D 첫 진입 시각적 시작 더 빠름
- "그냥 둘러보기" 단계에선 건물 0개, 경로 받으면 필요한 곳만 — 사용자 의도와 일치

### 후속 (미반영)
- 다음 단계: 사전 캐시를 서울 25개 자치구로 분할 + 좌표→자치구 매핑 lazy fetch → Overpass 의존 완전 제거

### 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)