### PR TITLE
feat: 자치구 단위 건물 캐시 — IndexedDB 영구 저장 (인프라만)

### DIFF
--- a/src/lib/buildings-cache.ts
+++ b/src/lib/buildings-cache.ts
@@ -1,0 +1,92 @@
+// IndexedDB 영구 캐시 — 자치구 단위 건물 데이터 저장.
+// localStorage(5MB)로는 자치구 1개(평균 3-10MB)도 못 담아서 IndexedDB 사용.
+//
+// 사용:
+//   const cached = await getCachedDistrict('jongno');
+//   if (!cached) { ...fetch from Overpass...; await setCachedDistrict('jongno', data); }
+//
+// schema:
+//   db: 'seoul-buildings' v1
+//   store: 'districts' (keyPath: 'slug')
+//   record: { slug, buildings: BuildingData[], cachedAt: number }
+
+import type { BuildingData } from './overpass';
+
+const DB_NAME = 'seoul-buildings';
+const DB_VERSION = 1;
+const STORE_NAME = 'districts';
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30일 — OSM 갱신 주기 감안
+
+interface DistrictRecord {
+  slug: string;
+  buildings: BuildingData[];
+  cachedAt: number;
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB unavailable'));
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'slug' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error('IndexedDB open failed'));
+  });
+  // 실패 시 다음 호출에서 재시도할 수 있게 promise 비움.
+  dbPromise.catch(() => { dbPromise = null; });
+  return dbPromise;
+}
+
+export async function getCachedDistrict(slug: string): Promise<BuildingData[] | null> {
+  let db: IDBDatabase;
+  try { db = await openDb(); } catch { return null; }
+
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const req = store.get(slug);
+    req.onsuccess = () => {
+      const record = req.result as DistrictRecord | undefined;
+      if (!record) { resolve(null); return; }
+      // TTL 만료 시 미스 처리. 별도 삭제는 다음 set 호출이 덮어쓰면서 자연 처리.
+      if (Date.now() - record.cachedAt > CACHE_TTL_MS) { resolve(null); return; }
+      resolve(record.buildings);
+    };
+    req.onerror = () => resolve(null);
+  });
+}
+
+export async function setCachedDistrict(slug: string, buildings: BuildingData[]): Promise<void> {
+  let db: IDBDatabase;
+  try { db = await openDb(); } catch { return; }
+
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const record: DistrictRecord = { slug, buildings, cachedAt: Date.now() };
+    const req = store.put(record);
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+  });
+}
+
+export async function clearAllDistricts(): Promise<void> {
+  let db: IDBDatabase;
+  try { db = await openDb(); } catch { return; }
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const req = tx.objectStore(STORE_NAME).clear();
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+  });
+}

--- a/src/lib/overpass.ts
+++ b/src/lib/overpass.ts
@@ -2,6 +2,9 @@
  * Overpass API를 통해 OpenStreetMap 건물 데이터를 가져옴
  */
 
+import { latLngToDistrict, type SeoulDistrict } from './seoul-districts';
+import { getCachedDistrict, setCachedDistrict } from './buildings-cache';
+
 // Pre-cached bounds for instant loading
 const CACHED_BOUNDS = { south: 37.562, west: 126.970, north: 37.585, east: 126.999 };
 
@@ -38,9 +41,27 @@ function distanceM(lat1: number, lon1: number, lat2: number, lon2: number): numb
 // Per-point building cache (keyed by "lat,lng")
 const pointCache = new Map<string, BuildingData[]>();
 
+function filterByDistance(buildings: BuildingData[], lat: number, lng: number, radiusM: number): BuildingData[] {
+  return buildings.filter((b) => {
+    const centroid = b.coords.reduce(
+      (acc, [blat, blon]) => [acc[0] + blat, acc[1] + blon],
+      [0, 0],
+    );
+    centroid[0] /= b.coords.length;
+    centroid[1] /= b.coords.length;
+    return distanceM(lat, lng, centroid[0], centroid[1]) <= radiusM;
+  });
+}
+
 /**
  * Fetch buildings within a radius around a point.
- * Uses cached data if available, otherwise falls back to Overpass.
+ *
+ * 우선순위:
+ *  1. pointCache (메모리 — 같은 (lat,lng,radius) 재요청)
+ *  2. 종로 사전 캐시 (정적 JSON, 즉시)
+ *  3. 자치구 IndexedDB 캐시 (한 번 받은 자치구는 영구 보관)
+ *  4. 자치구 전체 Overpass fetch → IndexedDB 저장 → 거리 필터
+ *  5. 폴백: point-radius Overpass fetch (자치구 매핑 실패 또는 모든 미러 실패 시)
  */
 export async function fetchBuildingsNearPoint(
   lat: number,
@@ -58,26 +79,77 @@ export async function fetchBuildingsNearPoint(
   const west = lng - lngOffset;
   const east = lng + lngOffset;
 
-  let allBuildings: BuildingData[];
-
+  // (2) 종로 사전 캐시 우선 — 가장 빠름.
   if (isWithinCachedBounds(south, west, north, east)) {
-    // Filter from local cache by distance
     const cached = await loadCachedBuildings();
-    allBuildings = cached.filter((b) => {
-      const centroid = b.coords.reduce(
-        (acc, [blat, blon]) => [acc[0] + blat, acc[1] + blon],
-        [0, 0],
-      );
-      centroid[0] /= b.coords.length;
-      centroid[1] /= b.coords.length;
-      return distanceM(lat, lng, centroid[0], centroid[1]) <= radiusM;
-    });
-  } else {
-    allBuildings = await fetchBuildings(south, west, north, east);
+    const filtered = filterByDistance(cached, lat, lng, radiusM);
+    pointCache.set(key, filtered);
+    return filtered;
   }
 
+  // (3-4) 자치구 캐시 경로.
+  const district = latLngToDistrict(lat, lng);
+  if (district) {
+    let districtBuildings = await getCachedDistrict(district.slug);
+    if (!districtBuildings) {
+      districtBuildings = await fetchBuildingsInDistrict(district);
+      if (districtBuildings.length > 0) {
+        // 비동기 저장 — 다음 호출 전에 완료될 보장은 없으나 fire-and-forget 으로 충분.
+        setCachedDistrict(district.slug, districtBuildings).catch(() => {});
+      }
+    }
+    if (districtBuildings.length > 0) {
+      const filtered = filterByDistance(districtBuildings, lat, lng, radiusM);
+      pointCache.set(key, filtered);
+      return filtered;
+    }
+  }
+
+  // (5) 폴백: point-radius Overpass (자치구 매핑 실패 또는 자치구 fetch 0건).
+  const allBuildings = await fetchBuildings(south, west, north, east);
   pointCache.set(key, allBuildings);
   return allBuildings;
+}
+
+/**
+ * 자치구 전체 bbox 를 한 번에 Overpass 로 받아옴. fetchBuildings 와 달리
+ * MAX_BBOX_DEGREES 클램핑이 없고 timeout 도 더 김.
+ */
+async function fetchBuildingsInDistrict(district: SeoulDistrict): Promise<BuildingData[]> {
+  const { south, west, north, east } = district.bbox;
+  const query = `
+    [out:json][timeout:120];
+    (
+      way["building"](${south},${west},${north},${east});
+      relation["building"](${south},${west},${north},${east});
+    );
+    out body;
+    >;
+    out skel qt;
+  `;
+
+  const controller = new AbortController();
+  const body = `data=${encodeURIComponent(query)}`;
+
+  try {
+    return await Promise.any(
+      OVERPASS_URLS.map(async (url) => {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body,
+          signal: AbortSignal.any([controller.signal, AbortSignal.timeout(30000)]),
+        });
+        if (!response.ok) throw new Error(`${response.status}`);
+        const data = await response.json();
+        controller.abort();
+        return parseBuildings(data);
+      }),
+    );
+  } catch {
+    console.warn(`Overpass: 자치구 ${district.slug} fetch 실패 — 빈 결과 반환`);
+    return [];
+  }
 }
 
 const OVERPASS_URLS = [

--- a/src/lib/seoul-districts.ts
+++ b/src/lib/seoul-districts.ts
@@ -1,0 +1,77 @@
+// 서울 25개 자치구 — bbox(SW-NE) 와 대표 중심점.
+// 좌표 → 자치구 매핑: 모든 자치구 bbox 안에 들어가는 후보 중 중심점에서
+// 가장 가까운 것을 선택 (대부분 자치구가 직사각 형태가 아니라 경계가 겹침).
+// Source: 서울 행정구역 공개 데이터(2024).
+
+export interface SeoulDistrict {
+  slug: string;       // 영문 식별자 — IndexedDB key, 파일명 등에 사용
+  name: string;       // 표시명
+  center: { lat: number; lng: number };
+  // bbox 는 Overpass 호출용 — 자치구 전체를 한 번에 받기 위한 사각형.
+  // 실제 경계보다 약간 크게 잡아 둠 (인접 자치구 일부 포함될 수 있으나 무해).
+  bbox: { south: number; west: number; north: number; east: number };
+}
+
+export const SEOUL_DISTRICTS: SeoulDistrict[] = [
+  { slug: 'jongno',       name: '종로구',   center: { lat: 37.5735, lng: 126.9788 }, bbox: { south: 37.554, west: 126.957, north: 37.625, east: 127.024 } },
+  { slug: 'jung',         name: '중구',     center: { lat: 37.5641, lng: 126.9979 }, bbox: { south: 37.545, west: 126.971, north: 37.581, east: 127.030 } },
+  { slug: 'yongsan',      name: '용산구',   center: { lat: 37.5326, lng: 126.9905 }, bbox: { south: 37.505, west: 126.961, north: 37.560, east: 127.029 } },
+  { slug: 'seongdong',    name: '성동구',   center: { lat: 37.5635, lng: 127.0367 }, bbox: { south: 37.531, west: 127.001, north: 37.587, east: 127.083 } },
+  { slug: 'gwangjin',     name: '광진구',   center: { lat: 37.5384, lng: 127.0825 }, bbox: { south: 37.512, west: 127.057, north: 37.567, east: 127.122 } },
+  { slug: 'dongdaemun',   name: '동대문구', center: { lat: 37.5744, lng: 127.0395 }, bbox: { south: 37.555, west: 127.013, north: 37.601, east: 127.082 } },
+  { slug: 'jungnang',     name: '중랑구',   center: { lat: 37.6066, lng: 127.0925 }, bbox: { south: 37.578, west: 127.063, north: 37.633, east: 127.130 } },
+  { slug: 'seongbuk',     name: '성북구',   center: { lat: 37.5894, lng: 127.0167 }, bbox: { south: 37.572, west: 126.985, north: 37.628, east: 127.057 } },
+  { slug: 'gangbuk',      name: '강북구',   center: { lat: 37.6396, lng: 127.0257 }, bbox: { south: 37.612, west: 126.988, north: 37.694, east: 127.061 } },
+  { slug: 'dobong',       name: '도봉구',   center: { lat: 37.6688, lng: 127.0470 }, bbox: { south: 37.644, west: 127.012, north: 37.702, east: 127.084 } },
+  { slug: 'nowon',        name: '노원구',   center: { lat: 37.6542, lng: 127.0568 }, bbox: { south: 37.612, west: 127.027, north: 37.706, east: 127.115 } },
+  { slug: 'eunpyeong',    name: '은평구',   center: { lat: 37.6027, lng: 126.9291 }, bbox: { south: 37.573, west: 126.901, north: 37.668, east: 126.965 } },
+  { slug: 'seodaemun',    name: '서대문구', center: { lat: 37.5791, lng: 126.9368 }, bbox: { south: 37.551, west: 126.911, north: 37.620, east: 126.972 } },
+  { slug: 'mapo',         name: '마포구',   center: { lat: 37.5663, lng: 126.9019 }, bbox: { south: 37.539, west: 126.872, north: 37.594, east: 126.952 } },
+  { slug: 'yangcheon',    name: '양천구',   center: { lat: 37.5170, lng: 126.8666 }, bbox: { south: 37.500, west: 126.838, north: 37.547, east: 126.895 } },
+  { slug: 'gangseo',      name: '강서구',   center: { lat: 37.5509, lng: 126.8495 }, bbox: { south: 37.521, west: 126.795, north: 37.602, east: 126.890 } },
+  { slug: 'guro',         name: '구로구',   center: { lat: 37.4954, lng: 126.8874 }, bbox: { south: 37.464, west: 126.836, north: 37.520, east: 126.917 } },
+  { slug: 'geumcheon',    name: '금천구',   center: { lat: 37.4519, lng: 126.9020 }, bbox: { south: 37.434, west: 126.876, north: 37.483, east: 126.926 } },
+  { slug: 'yeongdeungpo', name: '영등포구', center: { lat: 37.5264, lng: 126.8962 }, bbox: { south: 37.495, west: 126.870, north: 37.555, east: 126.939 } },
+  { slug: 'dongjak',      name: '동작구',   center: { lat: 37.5124, lng: 126.9393 }, bbox: { south: 37.487, west: 126.910, north: 37.539, east: 126.978 } },
+  { slug: 'gwanak',       name: '관악구',   center: { lat: 37.4783, lng: 126.9516 }, bbox: { south: 37.430, west: 126.917, north: 37.510, east: 126.985 } },
+  { slug: 'seocho',       name: '서초구',   center: { lat: 37.4837, lng: 127.0324 }, bbox: { south: 37.421, west: 126.985, north: 37.524, east: 127.069 } },
+  { slug: 'gangnam',      name: '강남구',   center: { lat: 37.5172, lng: 127.0473 }, bbox: { south: 37.464, west: 127.013, north: 37.554, east: 127.090 } },
+  { slug: 'songpa',       name: '송파구',   center: { lat: 37.5145, lng: 127.1059 }, bbox: { south: 37.480, west: 127.064, north: 37.554, east: 127.155 } },
+  { slug: 'gangdong',     name: '강동구',   center: { lat: 37.5301, lng: 127.1238 }, bbox: { south: 37.520, west: 127.105, north: 37.581, east: 127.181 } },
+];
+
+function distanceM(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371000;
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLon = (lon2 - lon1) * Math.PI / 180;
+  const a = Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * 좌표 → 자치구 매핑. bbox 후보 중 중심점이 가장 가까운 자치구 선택.
+ * 후보가 없으면 (서울 외) null. 서울 전역 어디든 매칭되도록 bbox는 약간 여유 있게 잡아둠.
+ */
+export function latLngToDistrict(lat: number, lng: number): SeoulDistrict | null {
+  const candidates = SEOUL_DISTRICTS.filter(
+    (d) => lat >= d.bbox.south && lat <= d.bbox.north && lng >= d.bbox.west && lng <= d.bbox.east,
+  );
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+
+  let best = candidates[0];
+  let bestDist = distanceM(lat, lng, best.center.lat, best.center.lng);
+  for (let i = 1; i < candidates.length; i++) {
+    const d = distanceM(lat, lng, candidates[i].center.lat, candidates[i].center.lng);
+    if (d < bestDist) {
+      bestDist = d;
+      best = candidates[i];
+    }
+  }
+  return best;
+}
+
+export function getDistrictBySlug(slug: string): SeoulDistrict | null {
+  return SEOUL_DISTRICTS.find((d) => d.slug === slug) ?? null;
+}


### PR DESCRIPTION
## 작업 내용

3D 건물 데이터를 **서울 자치구 단위로 캐싱**. 한 번 받은 자치구는 IndexedDB 에 30일간 영구 보관 → 재방문 시 외부 호출 없이 즉시 표시.

사용자 선택에 따라 **사전 정적 JSON 생성은 하지 않음** (repo size 영향 0). 첫 방문 자치구만 Overpass 1회 호출.

### 변경 파일
- `src/lib/seoul-districts.ts` (신규):
  - 서울 25개 자치구의 slug / 이름 / 중심점 / bbox 데이터
  - `latLngToDistrict(lat, lng)` — bbox 후보 → 중심점 최단거리로 자치구 결정
- `src/lib/buildings-cache.ts` (신규):
  - IndexedDB 네이티브 래퍼. DB `seoul-buildings`, store `districts`
  - `getCachedDistrict / setCachedDistrict / clearAllDistricts` API
  - TTL 30일 (OSM 갱신 주기 감안)
- `src/lib/overpass.ts`:
  - `fetchBuildingsNearPoint` 우선순위 재정의:
    1. pointCache (메모리)
    2. 종로 정적 캐시 (기존)
    3. 자치구 IDB 캐시
    4. 자치구 전체 Overpass fetch → IDB 저장
    5. 폴백: point-radius Overpass
  - `fetchBuildingsInDistrict(district)` 신규 — 자치구 bbox 한 번에 fetch, 30s timeout
  - `filterByDistance` helper 추출

### 효과
- 자치구 첫 방문: Overpass 1회 (자치구 전체, ~5km bbox) → IDB 저장 (자치구당 ~3-10MB)
- 자치구 재방문 (다른 stop / 새로고침 / 다음 세션): IDB hit → 외부 호출 0, 즉시
- 한 경로가 여러 stop 을 같은 자치구에 두면 첫 stop 때만 1회, 이후 즉시
- 사전 생성 JSON 0개 → repo size 변화 없음

### 트레이드오프 (의도적)
- 자치구 bbox 가 직사각이라 실제 경계와 약간 다름. 인접 자치구 일부 빌딩이 섞일 수 있으나 결국 거리 필터(500m)로 잘려서 무해
- IndexedDB 없는 환경(SSR / 일부 브라우저)에선 자동 폴백
- 자치구 매핑 실패(서울 외부 좌표) 시 폴백 point-radius

### 검증
- typecheck 0 errors
- 기존 13/13 tests pass

### 후속 (미반영)
- 자주 방문하는 자치구 6개 정도 정적 JSON 으로 ship → 첫 방문도 즉시 (repo +10-20MB)
- 자치구 polygon GeoJSON 추가 → 정확한 매핑

🤖 Generated with [Claude Code](https://claude.com/claude-code)