### PR TITLE
feat(gsap): Phase 1 — 답변 카드 순차 reveal + 일정 stop stagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "@chenglou/pretext": "^0.0.3",
     "@googlemaps/js-api-loader": "^2.0.2",
+    "@gsap/react": "^2.1.2",
     "@types/three": "^0.183.1",
+    "gsap": "^3.15.0",
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.577.0",
     "react": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,15 @@ importers:
       '@googlemaps/js-api-loader':
         specifier: ^2.0.2
         version: 2.0.2
+      '@gsap/react':
+        specifier: ^2.1.2
+        version: 2.1.2(gsap@3.15.0)(react@19.2.4)
       '@types/three':
         specifier: ^0.183.1
         version: 0.183.1
+      gsap:
+        specifier: ^3.15.0
+        version: 3.15.0
       lottie-react:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -423,6 +429,12 @@ packages:
 
   '@googlemaps/js-api-loader@2.0.2':
     resolution: {integrity: sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==}
+
+  '@gsap/react@2.1.2':
+    resolution: {integrity: sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==}
+    peerDependencies:
+      gsap: ^3.12.5
+      react: '>=17'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1250,6 +1262,9 @@ packages:
   graphql@16.13.2:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  gsap@3.15.0:
+    resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2334,6 +2349,11 @@ snapshots:
     dependencies:
       '@types/google.maps': 3.58.1
 
+  '@gsap/react@2.1.2(gsap@3.15.0)(react@19.2.4)':
+    dependencies:
+      gsap: 3.15.0
+      react: 19.2.4
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3120,6 +3140,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
+
+  gsap@3.15.0: {}
 
   has-flag@4.0.0: {}
 

--- a/src/components/chat/ItineraryCard.tsx
+++ b/src/components/chat/ItineraryCard.tsx
@@ -1,9 +1,17 @@
+import { useRef } from 'react';
 import { Clock, Star, MapPin, Footprints, Train, Bus, Car } from 'lucide-react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
 import type { Itinerary, TransportMode, Place } from '@/types';
 import { CATEGORY_CONFIG } from '@/lib/utils';
 import { useChatStore } from '@/stores/chatStore';
 import { useMapStore } from '@/stores/mapStore';
 import placesData from '@/mocks/places.json';
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' &&
+    !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}
 
 const ALL_PLACES = placesData as Place[];
 
@@ -25,6 +33,21 @@ export default function ItineraryCard({ itinerary, hideActions = false }: { itin
   const sendMessage = useChatStore((s) => s.sendMessage);
   const isLoading = useChatStore((s) => s.isLoading);
   const startNavigation = useMapStore((s) => s.startNavigation);
+  const stopsRef = useRef<HTMLDivElement>(null);
+
+  // 일정 stop 리스트를 위에서부터 차례로 reveal — 정적 등장보다 시선 유도가 자연스럽다.
+  useGSAP(() => {
+    if (prefersReducedMotion()) return;
+    const items = stopsRef.current?.children;
+    if (!items || items.length === 0) return;
+    gsap.from(Array.from(items), {
+      y: 12,
+      opacity: 0,
+      duration: 0.4,
+      ease: 'power2.out',
+      stagger: 0.08,
+    });
+  }, { scope: stopsRef });
 
   return (
     <div className="bg-bg-surface border border-border rounded-2xl overflow-hidden">
@@ -42,7 +65,7 @@ export default function ItineraryCard({ itinerary, hideActions = false }: { itin
       </div>
 
       {/* Stops */}
-      <div className="px-3 py-3 space-y-2">
+      <div ref={stopsRef} className="px-3 py-3 space-y-2">
         {itinerary.stops.map((stop, i) => {
           const place = ALL_PLACES.find((p) => p.id === stop.placeId);
           const cat = place ? CATEGORY_CONFIG[place.category] : null;

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -1,5 +1,7 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useRef } from 'react';
 import { Bookmark } from 'lucide-react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
 import type { Message, MessageSnapshot } from '@/types';
 import { useBookmarkStore } from '@/stores/bookmarkStore';
 import { useChatStore } from '@/stores/chatStore';
@@ -11,14 +13,36 @@ import FeedbackButton from './FeedbackButton';
 import ShareButton from './ShareButton';
 import { BlockRenderer } from './blocks';
 
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' &&
+    !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}
+
 export default memo(function MessageBubble({ message }: { message: Message }) {
   const isUser = message.role === 'user';
+  const bubbleRef = useRef<HTMLDivElement>(null);
 
   const conversationId = useChatStore((s) => s.sessionId);
   const toggleMessage = useBookmarkStore((s) => s.toggleMessage);
   const isMessageBookmarked = useBookmarkStore((s) =>
     s.messageItems.some((m) => m.messageId === message.id),
   );
+
+  // 어시스턴트 답변의 자식 섹션(text → places → itinerary → blocks → actions)을
+  // 작은 간격으로 순차 reveal. 사용자 메시지는 CSS animate-message 그대로 사용.
+  useGSAP(() => {
+    if (isUser) return;
+    if (prefersReducedMotion()) return;
+    const items = bubbleRef.current?.querySelectorAll<HTMLElement>('[data-reveal]');
+    if (!items || items.length === 0) return;
+    gsap.from(items, {
+      y: 8,
+      opacity: 0,
+      duration: 0.35,
+      ease: 'power2.out',
+      stagger: 0.07,
+    });
+  }, { scope: bubbleRef });
 
   const handleBookmark = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
@@ -37,7 +61,7 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
   }, [message, conversationId, toggleMessage]);
 
   return (
-    <div className="animate-message">
+    <div className={isUser ? 'animate-message' : ''} ref={bubbleRef}>
       {isUser ? (
         <div className="flex justify-end pl-12">
           <div className="bg-brand-subtle border border-brand/8 rounded-2xl rounded-br-sm px-3.5 py-2.5 text-[14px] leading-[1.6] text-text-primary">
@@ -49,27 +73,37 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
           <AgentMark size={28} className="mt-0.5" />
 
           <div className="flex-1 min-w-0 space-y-2">
-            <div className="text-[14px] leading-[1.7] text-text-primary">
+            <div data-reveal className="text-[14px] leading-[1.7] text-text-primary">
               {message.text}
             </div>
 
             {message.places && message.places.length > 0 && (
-              <PlaceCarousel places={message.places} />
+              <div data-reveal>
+                <PlaceCarousel places={message.places} />
+              </div>
             )}
 
             {message.itineraries && message.itineraries.length > 1 ? (
-              <div className="space-y-3">
+              <div data-reveal className="space-y-3">
                 {message.itineraries.map((it) => (
                   <ItineraryCard key={it.id} itinerary={it} />
                 ))}
               </div>
             ) : (
-              message.itinerary && <ItineraryCard itinerary={message.itinerary} />
+              message.itinerary && (
+                <div data-reveal>
+                  <ItineraryCard itinerary={message.itinerary} />
+                </div>
+              )
             )}
-            {message.booking && <BookingCard booking={message.booking} />}
+            {message.booking && (
+              <div data-reveal>
+                <BookingCard booking={message.booking} />
+              </div>
+            )}
 
             {message.blocks && message.blocks.length > 0 && (
-              <div className="space-y-2">
+              <div data-reveal className="space-y-2">
                 {message.blocks.map((block, i) => (
                   <BlockRenderer key={`${block.type}-${i}`} block={block} />
                 ))}
@@ -77,7 +111,7 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
             )}
 
             {/* 어시스턴트 메시지 액션 행 — 항상 노출 (호버/터치 모두 접근 가능) */}
-            <div className="flex items-center gap-1 pt-1">
+            <div data-reveal className="flex items-center gap-1 pt-1">
               <button
                 type="button"
                 onClick={handleBookmark}


### PR DESCRIPTION
## 작업 내용

GSAP Phase 1 도입. ROI 가 가장 큰 두 군데에 stagger reveal 적용.

### 패키지
- `gsap@3.15.0`
- `@gsap/react@2.1.2` (useGSAP 훅, cleanup 자동화)

### MessageBubble (assistant variant)
어시스턴트 답변이 도착할 때 자식 섹션을 순차 reveal:
```
text → places → itinerary → booking → blocks → action row
```
- 각 섹션에 `data-reveal` 마커, `useGSAP` 으로 일괄 stagger
- `y:8, opacity:0 → power2.out, duration 0.35s, stagger 0.07s`
- 사용자 메시지는 기존 CSS `animate-message` 그대로 유지 (변경 0)

### ItineraryCard
일정의 stop 카드들을 위에서부터 차례로 떨어지듯:
- stops 컨테이너 ref → 자식 stagger
- `y:12, opacity:0 → power2.out, duration 0.4s, stagger 0.08s`
- ItineraryCard 가 MessageBubble 의 [data-reveal] 안에 있어도 양쪽 애니메이션이 독립적으로 잘 합쳐짐

### 접근성
- 두 컴포넌트 모두 `prefers-reduced-motion: reduce` 감지 시 애니메이션 skip
- `useGSAP` scope cleanup 으로 unmount 누수 없음

### 비용
- 번들 추가 약 ~53KB gzipped (gsap core + @gsap/react)

### 검증
- typecheck 0 errors
- 13/13 tests pass

### 후속 Phase 2 후보
- PlaceCard ↔ 지도 마커 FLIP 전환
- 북마크 ☆ 토글 파티클
- 사이드바 spring easing

🤖 Generated with [Claude Code](https://claude.com/claude-code)