### PR TITLE
feat(gsap): Phase 2 — 사이드바 spring + 북마크 파티클 burst

### DIFF
--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -1,9 +1,16 @@
 import { memo, useState, useRef, useEffect, useCallback, type KeyboardEvent, type FocusEvent } from 'react';
 import { X, Plus, MessageCircle, Trash2, Settings, LogOut, User, RefreshCw, Pencil, Check } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
 import { useChatStore, type ChatSession } from '@/stores/chatStore';
 import { useAuthStore } from '@/stores/authStore';
 import { cn } from '@/lib/utils';
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' &&
+    !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}
 
 interface ChatSidebarProps {
   isOpen: boolean;
@@ -27,7 +34,23 @@ function formatDate(dateStr: string): string {
 
 export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) {
   const navigate = useNavigate();
+  const sidebarRef = useRef<HTMLDivElement>(null);
   const sessions = useChatStore((s) => s.sessions);
+
+  // GSAP spring 으로 사이드바 슬라이드 인/아웃 — back.out 으로 살짝 오버슈트.
+  useGSAP(() => {
+    const el = sidebarRef.current;
+    if (!el) return;
+    if (prefersReducedMotion()) {
+      gsap.set(el, { xPercent: isOpen ? 0 : -100 });
+      return;
+    }
+    gsap.to(el, {
+      xPercent: isOpen ? 0 : -100,
+      duration: isOpen ? 0.5 : 0.32,
+      ease: isOpen ? 'back.out(1.3)' : 'power3.in',
+    });
+  }, { dependencies: [isOpen], scope: sidebarRef });
   const sessionId = useChatStore((s) => s.sessionId);
   const newChat = useChatStore((s) => s.newChat);
   const loadSession = useChatStore((s) => s.loadSession);
@@ -65,10 +88,9 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
       )}
 
       <div
-        className={cn(
-          'fixed left-0 top-0 bottom-0 z-50 w-[300px] bg-bg-surface border-r border-border flex flex-col transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
-          isOpen ? 'translate-x-0' : '-translate-x-full',
-        )}
+        ref={sidebarRef}
+        style={{ transform: isOpen ? 'translateX(0)' : 'translateX(-100%)' }}
+        className="fixed left-0 top-0 bottom-0 z-50 w-[300px] bg-bg-surface border-r border-border flex flex-col will-change-transform"
       >
         <div className="flex items-center justify-between px-4 h-[52px] border-b border-border shrink-0">
           <h2 className="text-[14px] font-semibold text-text-primary">대화 내역</h2>

--- a/src/components/chat/PlaceCard.tsx
+++ b/src/components/chat/PlaceCard.tsx
@@ -1,10 +1,16 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { MapPin, Star, Bookmark } from 'lucide-react';
+import gsap from 'gsap';
 import type { Place, CongestionLevel } from '@/types';
 import { CATEGORY_CONFIG } from '@/lib/utils';
 import { useMapStore } from '@/stores/mapStore';
 import { useBookmarkStore } from '@/stores/bookmarkStore';
 import BookingForm from '@/components/booking/BookingForm';
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' &&
+    !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}
 
 const CONGESTION_BADGE: Record<CongestionLevel, { label: string; className: string }> = {
   low: { label: '한산', className: 'bg-green-100 text-green-700' },
@@ -22,6 +28,8 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
   const toggleBookmark = useBookmarkStore((s) => s.toggle);
   const isBookmarked = useBookmarkStore((s) => s.bookmarkedIds.includes(place.id));
   const [bookingOpen, setBookingOpen] = useState(false);
+  const bookmarkBtnRef = useRef<HTMLButtonElement>(null);
+  const burstRef = useRef<HTMLSpanElement>(null);
 
   const cat = CATEGORY_CONFIG[place.category];
 
@@ -31,7 +39,34 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
 
   const handleBookmark = (e: React.MouseEvent) => {
     e.stopPropagation();
+    const wasBookmarked = isBookmarked;
     toggleBookmark(place);
+
+    if (prefersReducedMotion()) return;
+
+    // 버튼 스케일 팝 — 항상 (추가/해제 모두 시각 피드백).
+    if (bookmarkBtnRef.current) {
+      gsap.fromTo(
+        bookmarkBtnRef.current,
+        { scale: 0.85 },
+        { scale: 1, duration: 0.35, ease: 'back.out(2.2)' },
+      );
+    }
+
+    // 파티클 버스트 — 추가 시에만.
+    if (!wasBookmarked && burstRef.current) {
+      const particles = burstRef.current.querySelectorAll<HTMLSpanElement>('.bm-particle');
+      const count = particles.length;
+      gsap.set(particles, { x: 0, y: 0, scale: 0.4, opacity: 1 });
+      gsap.to(particles, {
+        x: (i) => Math.cos((i / count) * Math.PI * 2 + Math.PI / 6) * 22,
+        y: (i) => Math.sin((i / count) * Math.PI * 2 + Math.PI / 6) * 22,
+        opacity: 0,
+        scale: 1.1,
+        duration: 0.55,
+        ease: 'power2.out',
+      });
+    }
   };
 
   return (
@@ -72,8 +107,9 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
                 </span>
               )}
               <button
+                ref={bookmarkBtnRef}
                 onClick={handleBookmark}
-                className="w-7 h-7 rounded-full flex items-center justify-center bg-bg-surface/90 backdrop-blur-sm transition-all duration-200 hover:scale-110 active:scale-95 cursor-pointer"
+                className="relative w-7 h-7 rounded-full flex items-center justify-center bg-bg-surface/90 backdrop-blur-sm hover:scale-110 cursor-pointer"
                 aria-label={isBookmarked ? '북마크 해제' : '북마크'}
                 aria-pressed={isBookmarked}
               >
@@ -83,6 +119,14 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
                   fill={isBookmarked ? '#F59E0B' : 'none'}
                   className={isBookmarked ? '' : 'text-text-primary'}
                 />
+                <span ref={burstRef} className="pointer-events-none absolute inset-0" aria-hidden="true">
+                  {[0, 1, 2, 3, 4, 5].map((i) => (
+                    <span
+                      key={i}
+                      className="bm-particle absolute top-1/2 left-1/2 w-1 h-1 -ml-0.5 -mt-0.5 rounded-full bg-amber-400 opacity-0"
+                    />
+                  ))}
+                </span>
               </button>
             </div>
             {place.congestion && (


### PR DESCRIPTION
## 작업 내용

GSAP Phase 2. 두 군데에 인터랙티브 polish.

### ChatSidebar — spring 슬라이드
- CSS transition + translate-x 클래스 제거, GSAP transform 으로 교체
- **열릴 때**: `back.out(1.3)` — 살짝 오버슈트하는 spring 느낌, duration 0.5s
- **닫힐 때**: `power3.in` — 빠르게 사라짐, duration 0.32s
- inline style 의 초기 transform 으로 첫 마운트 깜빡임 방지
- reduced-motion 시 `gsap.set` 으로 즉시 위치 변경

### PlaceCard 북마크 ☆
- **항상**: 클릭 시 버튼 scale `0.85 → 1` (back.out 2.2) — 즉각적 피드백
- **추가 시에만**: 6개 amber 파티클이 원형으로 튀어나오며 페이드 (반경 22px, 0.55s)
- 파티클은 absolute 로 버튼 중앙에서 시작, pointer-events 없음 (인터랙션 방해 X)
- reduced-motion 가드

### Phase 2 에서 보류한 것
**PlaceCard ↔ 지도 마커 cross-component FLIP**: 두 패널이 서로 다른 좌표계 + 클론 노드 동기화가 필요해서 별도 architectural 작업으로 분리. 다른 PR.

### 비용
- 추가 번들 0 (gsap 이미 Phase 1 에서 도입됨)
- 파티클은 mount 시 항상 DOM 6개만 존재 (안 보일 땐 opacity 0)

### 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)