### PR TITLE
feat(gsap): Phase 3 — FLIP 카드→마커 + ScrollTrigger 메시지 진입

### DIFF
--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -18,7 +18,7 @@ export default memo(function ChatMessages() {
   }, [messages, isLoading]);
 
   return (
-    <div ref={scrollRef} className="flex-1 overflow-y-auto overscroll-contain">
+    <div ref={scrollRef} data-chat-scroller className="flex-1 overflow-y-auto overscroll-contain">
       {hasOnlyWelcome && (
         <div className="flex flex-col items-center justify-center pt-14 pb-10 px-8 animate-fade-up">
           <div className="mb-7">

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useRef } from 'react';
 import { Bookmark } from 'lucide-react';
-import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
+import { gsap } from '@/lib/gsap-setup';
 import type { Message, MessageSnapshot } from '@/types';
 import { useBookmarkStore } from '@/stores/bookmarkStore';
 import { useChatStore } from '@/stores/chatStore';
@@ -28,8 +28,35 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
     s.messageItems.some((m) => m.messageId === message.id),
   );
 
+  // 외곽 컨테이너 진입 효과 — ScrollTrigger 로 스크롤 컨테이너 viewport 진입 시 페이드.
+  // 새로 도착한 메시지는 mount 시 이미 화면 안이라 즉시 발화 (animate-message 대체).
+  // 긴 히스토리에서 위로 스크롤 시 옛 메시지도 진입 타이밍에 자연스럽게 등장.
+  useGSAP(() => {
+    if (prefersReducedMotion()) return;
+    const el = bubbleRef.current;
+    if (!el) return;
+    const scroller = el.closest<HTMLElement>('[data-chat-scroller]');
+    if (!scroller) return;
+    const tween = gsap.from(el, {
+      y: 14,
+      opacity: 0,
+      duration: 0.45,
+      ease: 'power2.out',
+      scrollTrigger: {
+        trigger: el,
+        scroller,
+        start: 'top 95%',
+        once: true,
+      },
+    });
+    return () => {
+      tween.scrollTrigger?.kill();
+      tween.kill();
+    };
+  }, { scope: bubbleRef });
+
   // 어시스턴트 답변의 자식 섹션(text → places → itinerary → blocks → actions)을
-  // 작은 간격으로 순차 reveal. 사용자 메시지는 CSS animate-message 그대로 사용.
+  // 작은 간격으로 순차 reveal. 외곽 ScrollTrigger 와 독립적으로 mount 시 동작.
   useGSAP(() => {
     if (isUser) return;
     if (prefersReducedMotion()) return;
@@ -41,6 +68,7 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
       duration: 0.35,
       ease: 'power2.out',
       stagger: 0.07,
+      delay: 0.15,
     });
   }, { scope: bubbleRef });
 
@@ -61,7 +89,7 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
   }, [message, conversationId, toggleMessage]);
 
   return (
-    <div className={isUser ? 'animate-message' : ''} ref={bubbleRef}>
+    <div ref={bubbleRef}>
       {isUser ? (
         <div className="flex justify-end pl-12">
           <div className="bg-brand-subtle border border-brand/8 rounded-2xl rounded-br-sm px-3.5 py-2.5 text-[14px] leading-[1.6] text-text-primary">

--- a/src/components/chat/PlaceCard.tsx
+++ b/src/components/chat/PlaceCard.tsx
@@ -5,6 +5,7 @@ import type { Place, CongestionLevel } from '@/types';
 import { CATEGORY_CONFIG } from '@/lib/utils';
 import { useMapStore } from '@/stores/mapStore';
 import { useBookmarkStore } from '@/stores/bookmarkStore';
+import { flipToMarker } from '@/lib/flip-to-marker';
 import BookingForm from '@/components/booking/BookingForm';
 
 function prefersReducedMotion(): boolean {
@@ -30,10 +31,14 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
   const [bookingOpen, setBookingOpen] = useState(false);
   const bookmarkBtnRef = useRef<HTMLButtonElement>(null);
   const burstRef = useRef<HTMLSpanElement>(null);
+  const articleRef = useRef<HTMLElement>(null);
 
   const cat = CATEGORY_CONFIG[place.category];
 
   const handleViewOnMap = () => {
+    if (articleRef.current) {
+      flipToMarker(place, articleRef.current);
+    }
     selectPlace(place);
   };
 
@@ -72,6 +77,7 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
   return (
     <>
       <article
+        ref={articleRef}
         aria-label={`${place.name} - ${cat.label}`}
         onClick={handleViewOnMap}
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleViewOnMap(); }}

--- a/src/components/map/GoogleMap.tsx
+++ b/src/components/map/GoogleMap.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import type { Place } from '@/types';
 import { CATEGORY_CONFIG } from '@/lib/utils';
 import { loadMaps, loadMarker } from '@/lib/google-maps-loader';
+import { useMapStore } from '@/stores/mapStore';
 
 export type DisplayMarker = Place & { isBookmark?: boolean };
 
@@ -206,6 +207,42 @@ export default function GoogleMap({
 
     return () => { cancelled = true; };
   }, []);
+
+  // 지도 컨테이너 DOM 등록 — FLIP fallback 용 (마커 화면 밖일 때 컨테이너 중심 사용).
+  useEffect(() => {
+    const setEl = useMapStore.getState().setMapContainerEl;
+    setEl(containerRef.current);
+    return () => setEl(null);
+  }, []);
+
+  // 외부(PlaceCard FLIP 등)가 lat/lng → 화면 px 변환을 요청할 수 있도록 projector 등록.
+  // OverlayView 의 onAdd 이후 getProjection() 이 유효하므로, 그 시점에 store 에 함수 주입.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapReady || typeof google === 'undefined') return;
+
+    const setProjector = useMapStore.getState().setProjector;
+    const overlay = new google.maps.OverlayView();
+    overlay.onAdd = () => {
+      setProjector((lat: number, lng: number) => {
+        const proj = overlay.getProjection();
+        if (!proj) return null;
+        const point = proj.fromLatLngToContainerPixel(new google.maps.LatLng(lat, lng));
+        if (!point) return null;
+        const rect = containerRef.current?.getBoundingClientRect();
+        if (!rect) return null;
+        return { x: rect.left + point.x, y: rect.top + point.y };
+      });
+    };
+    overlay.draw = () => {};
+    overlay.onRemove = () => {};
+    overlay.setMap(map);
+
+    return () => {
+      overlay.setMap(null);
+      setProjector(null);
+    };
+  }, [mapReady]);
 
   // Create/update markers ONLY when the marker list changes (NOT on selection change)
   useEffect(() => {

--- a/src/lib/flip-to-marker.ts
+++ b/src/lib/flip-to-marker.ts
@@ -1,0 +1,83 @@
+// PlaceCard → 지도 마커 FLIP 전환.
+// 카드 클릭 시 카드의 현재 화면 위치에서 시작해 지도 마커 위치로 축소·이동하며 페이드.
+// 이 패널이 안 보이거나(모바일 단일 패널) projector 가 미등록(아직 지도 init 안 됨)이면 no-op.
+
+import { gsap, prefersReducedMotion } from './gsap-setup';
+import { useMapStore } from '@/stores/mapStore';
+import type { Place } from '@/types';
+
+export function flipToMarker(place: Place, fromEl: HTMLElement) {
+  if (prefersReducedMotion()) return;
+  if (typeof document === 'undefined') return;
+
+  const { projector, mapContainerEl } = useMapStore.getState();
+  if (!mapContainerEl) return; // 지도 패널이 화면에 없음 (모바일 단일 패널 등).
+
+  const containerRect = mapContainerEl.getBoundingClientRect();
+  if (containerRect.width === 0 || containerRect.height === 0) return;
+  const containerCenter = {
+    x: containerRect.left + containerRect.width / 2,
+    y: containerRect.top + containerRect.height / 2,
+  };
+
+  // 마커의 현재 화면 위치(projector). 화면 안에 있으면 정확한 좌표 사용,
+  // 아니면 컨테이너 중심 사용 (selectPlace 가 곧 그 위치로 pan 시킬 것).
+  const projected = projector?.(place.lat, place.lng);
+  const inView = projected
+    && projected.x >= containerRect.left && projected.x <= containerRect.right
+    && projected.y >= containerRect.top && projected.y <= containerRect.bottom;
+  const target = inView && projected ? projected : containerCenter;
+
+  const fromRect = fromEl.getBoundingClientRect();
+  if (fromRect.width === 0 || fromRect.height === 0) return;
+
+  // 카드와 마커 위치가 너무 가까우면(같은 패널 내) 모션이 무의미. skip.
+  const dx = target.x - (fromRect.left + fromRect.width / 2);
+  const dy = target.y - (fromRect.top + fromRect.height / 2);
+  if (Math.hypot(dx, dy) < 80) return;
+
+  const clone = document.createElement('div');
+  const bg = place.image ? `url(${place.image})` : '';
+  Object.assign(clone.style, {
+    position: 'fixed',
+    top: `${fromRect.top}px`,
+    left: `${fromRect.left}px`,
+    width: `${fromRect.width}px`,
+    height: `${fromRect.height}px`,
+    backgroundImage: bg,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    backgroundColor: '#e5e7eb',
+    borderRadius: '16px',
+    boxShadow: '0 12px 32px rgba(0,0,0,0.2)',
+    pointerEvents: 'none',
+    zIndex: '9999',
+    overflow: 'hidden',
+    willChange: 'transform, opacity',
+    opacity: '0.95',
+  } as Partial<CSSStyleDeclaration>);
+  document.body.appendChild(clone);
+
+  // 카드 → 마커: top/left 로 직접 가는 대신 transform 으로 이동·축소 (GPU).
+  // 시작 transform 0,0 → 목표 transform 으로 보간.
+  const finalSize = 44; // 마커 원의 시각적 크기
+  const finalX = target.x - finalSize / 2 - fromRect.left;
+  const finalY = target.y - finalSize / 2 - fromRect.top;
+  const scaleX = finalSize / fromRect.width;
+  const scaleY = finalSize / fromRect.height;
+
+  gsap.to(clone, {
+    x: finalX,
+    y: finalY,
+    scaleX,
+    scaleY,
+    opacity: 0,
+    borderRadius: '999px',
+    duration: 0.65,
+    ease: 'power2.inOut',
+    transformOrigin: 'top left',
+    onComplete: () => {
+      clone.remove();
+    },
+  });
+}

--- a/src/lib/gsap-setup.ts
+++ b/src/lib/gsap-setup.ts
@@ -1,0 +1,14 @@
+// GSAP 플러그인 등록 — 진입 시점에 1회. main.tsx 에서 import.
+// ScrollTrigger 외에 추가 플러그인이 생기면 여기에 register.
+
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+export { gsap, ScrollTrigger };
+
+export function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' &&
+    !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,8 @@ import './globals.css';
 import { useAuthStore } from '@/stores/authStore';
 import RequireAuth from '@/components/auth/RequireAuth';
 import Toaster from '@/components/ui/Toaster';
+// GSAP 플러그인(ScrollTrigger 등) 진입 시점에 1회 등록.
+import '@/lib/gsap-setup';
 
 // MSW — dev 환경에서 BE 미배포 상태 검수용.
 // VITE_DISABLE_MSW=true 로 끌 수 있음 (실서버 붙일 때).

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -10,6 +10,10 @@ export interface NavigationState {
   isPlaying: boolean;
 }
 
+// lat/lng → viewport pixel 좌표 변환기. GoogleMap 이 마운트 시 등록, 언마운트 시 null.
+// PlaceCard → 마커 FLIP 애니메이션이 이 함수를 통해 대상 좌표를 알아낸다.
+export type MapProjector = (lat: number, lng: number) => { x: number; y: number } | null;
+
 interface MapStore {
   markers: Place[];
   route: RoutePoint[];
@@ -19,10 +23,17 @@ interface MapStore {
   // Navigation
   navigation: NavigationState | null;
 
+  // Projection (FLIP 용)
+  projector: MapProjector | null;
+  // 지도 컨테이너 DOM — FLIP 도착 fallback (마커가 화면 밖일 때 컨테이너 중심으로).
+  mapContainerEl: HTMLElement | null;
+
   setMarkers: (places: Place[]) => void;
   setRoute: (route: RoutePoint[]) => void;
   selectPlace: (place: Place | null) => void;
   clearMap: () => void;
+  setProjector: (fn: MapProjector | null) => void;
+  setMapContainerEl: (el: HTMLElement | null) => void;
 
   // Navigation actions
   startNavigation: (itinerary: Itinerary) => void;
@@ -65,6 +76,8 @@ export const useMapStore = create<MapStore>((set, get) => ({
   selectedPlace: null,
   mapCenter: SEOUL_CENTER,
   navigation: null,
+  projector: null,
+  mapContainerEl: null,
 
   setMarkers: (places) =>
     set({
@@ -82,6 +95,10 @@ export const useMapStore = create<MapStore>((set, get) => ({
     }),
 
   clearMap: () => set({ markers: [], route: [], selectedPlace: null, mapCenter: SEOUL_CENTER }),
+
+  setProjector: (fn) => set({ projector: fn }),
+
+  setMapContainerEl: (el) => set({ mapContainerEl: el }),
 
   startNavigation: (itinerary) => {
     const places = getPlacesForItinerary(itinerary);


### PR DESCRIPTION
## 작업 내용

GSAP Phase 3. 두 가지 인터랙티브 효과 추가.

### 1. PlaceCard → 지도 마커 FLIP (cross-component)
카드 클릭 시 카드의 시각적 클론이 지도 마커 위치로 축소·이동하며 페이드. 채팅 ↔ 지도 컨텍스트가 시각적으로 연결.

**구현**:
- `lib/gsap-setup.ts` — ScrollTrigger 플러그인 진입 시점 1회 등록
- `lib/flip-to-marker.ts` — FLIP 유틸. document.body 에 fixed-positioned 클론 생성 → transform 으로 카드 rect → 마커 위치로 0.65s 보간
- `stores/mapStore.ts` — `projector` (MapProjector) + `mapContainerEl` 상태/세터
- `components/map/GoogleMap.tsx`:
  - 컨테이너 DOM ref 를 store 에 등록 (FLIP fallback)
  - OverlayView 로 projection 캡처 → `setProjector(lat,lng → px)`
- `components/chat/PlaceCard.tsx` — `articleRef` + `handleViewOnMap` 에서 flipToMarker 호출

**도착 좌표 우선순위**:
1. 마커가 현재 viewport 안에 있음 → projector 의 정확한 px 좌표
2. viewport 밖이거나 projector 없음 → 컨테이너 중심 (selectPlace 가 곧 거기로 pan)

**Skip 조건**:
- 카드 ↔ 마커 거리 80px 미만 (모바일 단일 패널 등)
- `mapContainerEl` 없음 (지도 패널 미렌더)
- `prefers-reduced-motion`

### 2. ScrollTrigger 메시지 진입
- `components/chat/MessageBubble.tsx` — 외곽 wrapper 에 ScrollTrigger 기반 `gsap.from`
  - `scroller = closest('[data-chat-scroller]')`
  - `start: 'top 95%'`, `once: true`
  - **새 메시지 도착**: mount 시점에 이미 viewport 안 (auto-scroll bottom) → 즉시 발화. CSS `animate-message` 대체
  - **긴 히스토리 위로 스크롤**: 옛 메시지가 진입 타이밍에 자연스럽게 등장
- 기존 inner 섹션 stagger 는 150ms 딜레이로 외곽 진입 후 시작 (시각적 분리)
- `components/chat/ChatMessages.tsx` — scroller 에 `data-chat-scroller` 마커
- `main.tsx` — `import '@/lib/gsap-setup'` 로 ScrollTrigger 등록

### 공통 안전장치
- 모든 진입점에서 `prefers-reduced-motion: reduce` 가드
- `useGSAP` scope 자동 cleanup
- `tween.scrollTrigger?.kill()` 로 unmount 시 트리거 명시적 정리

### 비용
- ScrollTrigger 플러그인 추가 ~14KB gzipped
- FLIP 은 클릭 시 클론 DOM 1개 임시 생성 후 제거 (메모리 영향 미미)

### 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)