### PR TITLE
fix: 사이드바 안 보이는 문제 — inline style 과 GSAP transform 충돌

### DIFF
--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -38,15 +38,24 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
   const sessions = useChatStore((s) => s.sessions);
 
   // GSAP spring 으로 사이드바 슬라이드 인/아웃 — back.out 으로 살짝 오버슈트.
+  // ⚠ JSX 에 inline style.transform 을 두면 React 가 매 렌더마다 덮어써서 GSAP 와 충돌.
+  //    transform 은 GSAP 가 단독 관리. 초기 위치는 useGSAP 의 first-run 분기에서 set.
+  const firstRun = useRef(true);
   useGSAP(() => {
     const el = sidebarRef.current;
     if (!el) return;
+    const targetX = isOpen ? 0 : -100;
+    if (firstRun.current) {
+      firstRun.current = false;
+      gsap.set(el, { xPercent: targetX });
+      return;
+    }
     if (prefersReducedMotion()) {
-      gsap.set(el, { xPercent: isOpen ? 0 : -100 });
+      gsap.set(el, { xPercent: targetX });
       return;
     }
     gsap.to(el, {
-      xPercent: isOpen ? 0 : -100,
+      xPercent: targetX,
       duration: isOpen ? 0.5 : 0.32,
       ease: isOpen ? 'back.out(1.3)' : 'power3.in',
     });
@@ -89,7 +98,6 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
 
       <div
         ref={sidebarRef}
-        style={{ transform: isOpen ? 'translateX(0)' : 'translateX(-100%)' }}
         className="fixed left-0 top-0 bottom-0 z-50 w-[300px] bg-bg-surface border-r border-border flex flex-col will-change-transform"
       >
         <div className="flex items-center justify-between px-4 h-[52px] border-b border-border shrink-0">


### PR DESCRIPTION
## 증상
PR #72 머지 후 대화 기록 사이드바를 열어도 안 보이거나 깜빡임.

## 원인
JSX 의 `style={{ transform: isOpen ? 'translateX(0)' : 'translateX(-100%)' }}` 가 React 의 재렌더 사이클마다 GSAP 가 설정한 transform 을 덮어씀. React 와 GSAP 가 매 프레임 transform 소유권을 두고 경쟁 → 시각적으로 사라지거나 위치가 꼬임.

## 수정
- `style.transform` JSX 인라인 제거
- `useGSAP` 에 firstRun 가드 추가: 첫 마운트 시 `gsap.set(xPercent: isOpen ? 0 : -100)` 으로 즉시 위치 설정 (useGSAP 가 useLayoutEffect 기반이라 paint 전 적용 → 플래시 없음)
- 이후 isOpen 변경 시에만 gsap.to 애니메이션

## 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)