### PR TITLE
fix: 일정 stop 카테고리 채팅↔지도 불일치 (공통 helper 통일)

### DIFF
--- a/src/components/chat/ItineraryCard.tsx
+++ b/src/components/chat/ItineraryCard.tsx
@@ -4,6 +4,7 @@ import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
 import type { Itinerary, TransportMode, Place } from '@/types';
 import { CATEGORY_CONFIG } from '@/lib/utils';
+import { deriveStopCategory } from '@/lib/stop-category';
 import { useChatStore } from '@/stores/chatStore';
 import { useMapStore } from '@/stores/mapStore';
 import placesData from '@/mocks/places.json';
@@ -68,7 +69,9 @@ export default function ItineraryCard({ itinerary, hideActions = false }: { itin
       <div ref={stopsRef} className="px-3 py-3 space-y-2">
         {itinerary.stops.map((stop, i) => {
           const place = ALL_PLACES.find((p) => p.id === stop.placeId);
-          const cat = place ? CATEGORY_CONFIG[place.category] : null;
+          // 카테고리는 stop.category(BE) → mock → 'tourism' 우선순위로 결정.
+          // 지도 패널과 동일 helper 를 써서 양쪽 일관성 보장.
+          const cat = CATEGORY_CONFIG[deriveStopCategory(stop)];
           const isLast = i >= itinerary.stops.length - 1;
           const TransportIcon = !isLast ? TRANSPORT_ICON[stop.transportToNext] : null;
 

--- a/src/components/map/ItineraryStopsList.tsx
+++ b/src/components/map/ItineraryStopsList.tsx
@@ -3,7 +3,7 @@ import { Star, MapPin } from 'lucide-react';
 import type { NavigationState } from '@/stores/mapStore';
 import { useMapStore } from '@/stores/mapStore';
 import { CATEGORY_CONFIG } from '@/lib/utils';
-import type { PlaceCategory } from '@/types';
+import { deriveStopCategory } from '@/lib/stop-category';
 
 type Section = '아침' | '오후' | '저녁';
 const SECTION_ORDER: Section[] = ['아침', '오후', '저녁'];
@@ -43,7 +43,7 @@ export default memo(function ItineraryStopsList({ navigation, onStopSelect }: Pr
             <h3 className="text-[14px] font-semibold text-text-secondary mb-3">{section}</h3>
             <div className="space-y-3">
               {stops.map((stop, idxInSection) => {
-                const cat = CATEGORY_CONFIG[(stop.category ?? 'tourism') as PlaceCategory];
+                const cat = CATEGORY_CONFIG[deriveStopCategory(stop)];
                 const isCurrent = itinerary.stops[stopIndex]?.placeId === stop.placeId;
                 const isSelected = selectedPlace?.id === stop.placeId;
                 const globalIdx = itinerary.stops.findIndex((s) => s.placeId === stop.placeId);

--- a/src/lib/stop-category.ts
+++ b/src/lib/stop-category.ts
@@ -1,0 +1,21 @@
+// 일정(course) 스톱의 카테고리 결정 — 모든 패널이 동일한 우선순위 사용.
+//
+// 우선순위:
+//   1) stop.category      — BE 가 normalize 해서 보낸 값 (가장 신뢰)
+//   2) mocks/places.json  — id 매칭되면 mock 의 category (레거시 mock 코스)
+//   3) 'tourism'          — 안전한 기본값
+//
+// 이전 버그: chat ItineraryCard 는 (2)만, map 측은 (1)+(3)만 사용해서
+// 같은 stop 이 두 패널에서 다른 카테고리로 보이는 불일치 발생.
+
+import type { Place, PlaceCategory, ItineraryStop } from '@/types';
+import placesData from '@/mocks/places.json';
+
+const ALL_PLACES = placesData as Place[];
+
+export function deriveStopCategory(stop: ItineraryStop): PlaceCategory {
+  if (stop.category) return stop.category;
+  const mock = ALL_PLACES.find((p) => p.id === stop.placeId);
+  if (mock) return mock.category;
+  return 'tourism';
+}

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { Place, RoutePoint, Itinerary } from '@/types';
+import { deriveStopCategory } from '@/lib/stop-category';
 import placesData from '@/mocks/places.json';
 
 const allPlaces = placesData as Place[];
@@ -47,17 +48,19 @@ interface MapStore {
 const SEOUL_CENTER = { lat: 37.5665, lng: 126.978 };
 
 function getPlacesForItinerary(itinerary: Itinerary): Place[] {
-  // 1순위: places.json 매칭 (레거시 mock 일정).
-  // 2순위: SSE-driven 일정 — stop 자체 필드(lat/lng/imageUrl 등)로 Place 합성.
+  // 마커용 Place 합성. 카테고리는 deriveStopCategory 로 통일된 우선순위 사용:
+  //   stop.category(BE) → mock category → 'tourism'.
+  // ItineraryCard/ItineraryStopsList 가 같은 helper 를 쓰므로 패널 간 일관성 보장.
   return itinerary.stops
     .map((stop): Place | null => {
+      const category = deriveStopCategory(stop);
       const matched = allPlaces.find((p) => p.id === stop.placeId);
-      if (matched) return matched;
+      if (matched) return { ...matched, category };
       if (stop.lat == null || stop.lng == null) return null;
       return {
         id: stop.placeId,
         name: stop.placeName,
-        category: stop.category ?? 'tourism',
+        category,
         address: stop.address ?? '',
         lat: stop.lat,
         lng: stop.lng,


### PR DESCRIPTION
## 증상
같은 일정의 같은 장소가 채팅 ItineraryCard 와 지도 패널에서 다른 카테고리로 표시.
예) 채팅에서 5개 모두 '관광' 으로 보이는데 지도에선 2개 관광 + 3개 문화.

## 원인
세 곳이 각각 다른 소스 / 우선순위로 카테고리를 결정:
- **채팅 `ItineraryCard.tsx:70-71`** — `mocks/places.json` 만 lookup, `stop.category` 무시
- **지도 `ItineraryStopsList.tsx:46`** — `stop.category ?? 'tourism'`
- **지도 마커 (`mapStore.getPlacesForItinerary`)** — id 매칭 시 mock 통째 반환, 아니면 `stop.category ?? 'tourism'`

→ BE 카테고리와 mock 카테고리가 다른 경우 (BE 가 PR #97 이후 normalize 한 더 정확한 값을 보내는데 mock 은 옛 분류) 패널 간 시각 불일치.

## 수정
**lib/stop-category.ts (신규)** — 공통 `deriveStopCategory(stop)`:
```
1) stop.category (BE normalize 결과 — 가장 신뢰)
2) mocks/places.json id 매칭 결과
3) 'tourism' fallback
```

3개 사용처가 같은 helper 호출:
- `ItineraryCard.tsx` — `CATEGORY_CONFIG[deriveStopCategory(stop)]`
- `ItineraryStopsList.tsx` — 동일
- `mapStore.getPlacesForItinerary` — mock 매칭 시에도 카테고리만 derive 결과로 override (image/summary 등 다른 mock 필드는 보존)

## 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)