### PR TITLE
feat: TypingIndicator 에 SSE 진행 상태 메시지 표시

### DIFF
--- a/src/components/chat/StreamingMessage.tsx
+++ b/src/components/chat/StreamingMessage.tsx
@@ -5,9 +5,10 @@ import StreamingBubble from './StreamingBubble';
 export default function StreamingMessage() {
   const isLoading = useChatStore((s) => s.isLoading);
   const streamingText = useChatStore((s) => s.streamingText);
+  const currentStatus = useChatStore((s) => s.currentStatus);
   const selectedAgent = useChatStore((s) => s.selectedAgent);
 
   if (!isLoading) return null;
-  if (!streamingText) return <TypingIndicator agent={selectedAgent} />;
+  if (!streamingText) return <TypingIndicator agent={selectedAgent} status={currentStatus} />;
   return <StreamingBubble text={streamingText} agent={selectedAgent} />;
 }

--- a/src/components/chat/TypingIndicator.tsx
+++ b/src/components/chat/TypingIndicator.tsx
@@ -1,18 +1,23 @@
 import type { AgentType } from '@/types';
 import AgentMark from '../agent/AgentMark';
 
-export default function TypingIndicator({ agent }: { agent: AgentType }) {
+export default function TypingIndicator({ agent, status }: { agent: AgentType; status?: string }) {
   return (
     <div className="flex gap-3 animate-message">
       <AgentMark agent={agent} size={28} />
-      <div className="flex items-center gap-[5px] pt-2">
-        {[0, 1, 2].map((i) => (
-          <span
-            key={i}
-            className="w-[5px] h-[5px] rounded-full bg-text-muted"
-            style={{ animation: 'dot 1.4s ease-in-out infinite', animationDelay: `${i * 0.16}s` }}
-          />
-        ))}
+      <div className="flex items-center gap-2 pt-1.5">
+        <div className="flex items-center gap-[5px]">
+          {[0, 1, 2].map((i) => (
+            <span
+              key={i}
+              className="w-[5px] h-[5px] rounded-full bg-text-muted"
+              style={{ animation: 'dot 1.4s ease-in-out infinite', animationDelay: `${i * 0.16}s` }}
+            />
+          ))}
+        </div>
+        {status && (
+          <span className="text-[13px] text-text-muted">{status}</span>
+        )}
       </div>
     </div>
   );

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -175,6 +175,9 @@ interface ChatStore {
   messages: Message[];
   isLoading: boolean;
   streamingText: string;
+  // BE 가 SSE status 이벤트로 보내는 진행 상황 메시지 ("코스를 계획하고 있어요..." 등).
+  // text_stream 첫 delta 도착 시 비움 (실 답변이 흐르기 시작하면 상태 텍스트 무의미).
+  currentStatus: string;
   selectedAgent: AgentType;
   sessionId: string;
 
@@ -207,6 +210,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   messages: [],
   isLoading: false,
   streamingText: '',
+  currentStatus: '',
   selectedAgent: 'claude',
   sessionId: `session-${Date.now()}`,
   sessions: [],
@@ -237,7 +241,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     };
 
     const updatedMessages = [...messages, userMsg];
-    set({ messages: updatedMessages, isLoading: true, streamingText: '' });
+    set({ messages: updatedMessages, isLoading: true, streamingText: '', currentStatus: '' });
 
     // SSE 누적 버퍼 — done 시 한 번에 Message 빌드.
     let acc = '';
@@ -254,7 +258,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         text_stream: (data) => {
           if (data.type === 'text_stream') {
             acc += data.delta ?? data.content ?? '';
-            set({ streamingText: acc });
+            // 실제 답변이 흐르기 시작하면 진행 상태 텍스트는 더 이상 의미 없음.
+            set({ streamingText: acc, currentStatus: '' });
           }
         },
         places: (data) => {
@@ -292,7 +297,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         map_markers: (data) => otherBlocks.push(data),
         map_route: (data) => otherBlocks.push(data),
         intent: () => {},
-        status: () => {},
+        status: (data) => {
+          // BE 가 보내는 진행 상황 메시지를 TypingIndicator 에 노출.
+          if (data.type === 'status' && data.message) {
+            set({ currentStatus: data.message });
+          }
+        },
         done: (data) => {
           if (data.type === 'done' && typeof data.message_id === 'number') {
             beMessageId = data.message_id;
@@ -354,6 +364,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       messages: allMessages,
       isLoading: false,
       streamingText: '',
+      currentStatus: '',
       sessions: updatedSessions,
     });
 


### PR DESCRIPTION
## 작업 내용
BE 가 SSE 로 보내는 진행 상태 메시지를 점 3개 옆에 노출.

### 예시
- "의도를 분석하고 있어요..." (intent_router)
- "질문을 정리하고 있어요..." (query_preprocessor)
- "코스를 계획하고 있어요..." (course_plan)
- "이미지를 분석하고 있어요..." (image_search)

### 이전
`chatStore.ts` 의 `status: () => {}` — 상태 이벤트 무시. 점 3개만 무한 반복.

### 변경
- `chatStore.ts`:
  - `currentStatus: string` 상태 추가
  - `send` 시작 시 리셋
  - `status` 핸들러에서 `data.message` 캡처
  - `text_stream` 첫 delta 도착 시 자동 리셋 (실 답변 시작 = 상태 무의미)
  - 최종 정리에도 빈 문자열로 리셋
- `TypingIndicator.tsx` — `status?: string` prop 추가, 점 옆에 회색 텍스트
- `StreamingMessage.tsx` — store 의 currentStatus 를 prop 으로 전달

### UX 흐름
1. 사용자 전송 → `점점점` 만
2. 0~수 초 후 BE status 이벤트 → `점점점 코스를 계획하고 있어요...`
3. status 메시지가 여러 단계 거치면 자동 갱신
4. text_stream 시작 → 점 사라지고 실제 답변 표시

### 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)