### PR TITLE
perf(3d): Phase 2 — OSM 타일 영구 캐시 + 코스 응답 시 백그라운드 prefetch

### DIFF
--- a/src/lib/prefetch-3d.ts
+++ b/src/lib/prefetch-3d.ts
@@ -1,0 +1,41 @@
+// 코스 응답 도착 시점에 3D 데이터/모듈을 백그라운드로 미리 받아두기.
+// 사용자가 "3D 보기" 토글을 누르거나 "지도에서 보기" 버튼을 누르기 전에
+// (1) Three.js 모듈 chunk 다운로드, (2) 자치구 빌딩 데이터(IndexedDB 캐시)
+// 를 채워서 클릭 → 표시 사이의 대기 시간을 0 에 수렴시킨다.
+//
+// 모든 호출은 fire-and-forget. 실패 silent.
+
+import type { ItineraryStop } from '@/types';
+
+type LatLng = { lat: number; lng: number };
+
+function takeCoords(stops: ItineraryStop[]): LatLng[] {
+  return stops
+    .map((s) => (s.lat != null && s.lng != null ? { lat: s.lat, lng: s.lng } : null))
+    .filter((c): c is LatLng => c !== null);
+}
+
+let prefetchInFlight = false;
+
+export function prefetchCourse3D(stops: ItineraryStop[]) {
+  if (prefetchInFlight) return;
+  const coords = takeCoords(stops);
+  if (coords.length === 0) return;
+  prefetchInFlight = true;
+
+  // 1) 3D 모듈 chunk 백그라운드 다운로드.
+  void import('@/components/map/ThreeMap');
+  // 2) 자치구 빌딩 데이터 prefetch (IDB 캐시 적재).
+  void (async () => {
+    try {
+      const { fetchBuildingsNearPoint } = await import('./overpass');
+      await Promise.allSettled(
+        coords.map((c) => fetchBuildingsNearPoint(c.lat, c.lng, 500)),
+      );
+    } catch {
+      /* silent */
+    } finally {
+      prefetchInFlight = false;
+    }
+  })();
+}

--- a/src/lib/three-scene.ts
+++ b/src/lib/three-scene.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import type { BuildingData } from './overpass';
+import { loadTileTexture } from './tile-cache';
 import type { Place } from '@/types';
 
 // ── Tile helpers ──
@@ -153,9 +154,6 @@ export class MapScene3D {
     const tlTile = lonLatToTile(bounds.west, bounds.north, zoom);
     const brTile = lonLatToTile(bounds.east, bounds.south, zoom);
 
-    const loader = new THREE.TextureLoader();
-    loader.crossOrigin = 'anonymous';
-
     const promises: Promise<void>[] = [];
 
     for (let tx = tlTile.x - 1; tx <= brTile.x + 1; tx++) {
@@ -166,26 +164,20 @@ export class MapScene3D {
         const tl = this.latLonToLocal(nw.lat, nw.lon);
         const br = this.latLonToLocal(se.lat, se.lon);
 
-        const p = new Promise<void>((resolve) => {
-          loader.load(url, (texture) => {
-            texture.minFilter = THREE.LinearFilter;
-            texture.magFilter = THREE.LinearFilter;
-            texture.colorSpace = THREE.SRGBColorSpace;
+        const p = loadTileTexture(url).then((texture) => {
+          if (!texture) return;
+          const geo = new THREE.BufferGeometry();
+          geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array([
+            tl.x, 0, tl.z, br.x, 0, tl.z, tl.x, 0, br.z, br.x, 0, br.z,
+          ]), 3));
+          geo.setAttribute('uv', new THREE.BufferAttribute(new Float32Array([
+            0, 1, 1, 1, 0, 0, 1, 0,
+          ]), 2));
+          geo.setIndex([0, 2, 1, 1, 2, 3]);
+          geo.computeVertexNormals();
 
-            const geo = new THREE.BufferGeometry();
-            geo.setAttribute('position', new THREE.BufferAttribute(new Float32Array([
-              tl.x, 0, tl.z, br.x, 0, tl.z, tl.x, 0, br.z, br.x, 0, br.z,
-            ]), 3));
-            geo.setAttribute('uv', new THREE.BufferAttribute(new Float32Array([
-              0, 1, 1, 1, 0, 0, 1, 0,
-            ]), 2));
-            geo.setIndex([0, 2, 1, 1, 2, 3]);
-            geo.computeVertexNormals();
-
-            const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide });
-            group.add(new THREE.Mesh(geo, mat));
-            resolve();
-          }, undefined, () => resolve());
+          const mat = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide });
+          group.add(new THREE.Mesh(geo, mat));
         });
         promises.push(p);
       }

--- a/src/lib/tile-cache.ts
+++ b/src/lib/tile-cache.ts
@@ -1,0 +1,66 @@
+// OSM 타일 영구 캐시 — Cache Storage (Cache API) 기반.
+// THREE.TextureLoader 가 < img > 로 매번 HTTP fetch 하는 대신, fetch + cache.match
+// 로 디스크에 보관해 두 번째 진입부터 즉시 표시. ImageBitmap 사용해 blob URL
+// 라이프사이클 이슈 회피.
+//
+// 폴백: Cache API 또는 createImageBitmap 미지원 시 기존 TextureLoader 경로 사용.
+
+import * as THREE from 'three';
+
+const CACHE_NAME = 'osm-tiles-v1';
+
+async function loadFromCacheOrNetwork(url: string): Promise<Blob | null> {
+  if (typeof caches === 'undefined') return null;
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    let resp = await cache.match(url);
+    if (!resp) {
+      resp = await fetch(url, { mode: 'cors' });
+      if (!resp.ok) return null;
+      // 비동기 저장 — 실패해도 캐시 미스로만 처리 (storage quota 등).
+      cache.put(url, resp.clone()).catch(() => {});
+    }
+    return await resp.blob();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 타일 URL → THREE.Texture. Cache Storage 우선 hit → 미스 시 네트워크 + 캐싱.
+ * 모든 폴백 실패 시 일반 TextureLoader 로 fallback (CORS only fetch 가 막힌 환경 등).
+ */
+export async function loadTileTexture(url: string): Promise<THREE.Texture | null> {
+  // 1) Cache 우선 시도.
+  const blob = await loadFromCacheOrNetwork(url);
+  if (blob && typeof createImageBitmap === 'function') {
+    try {
+      const bitmap = await createImageBitmap(blob);
+      const texture = new THREE.Texture(bitmap);
+      texture.minFilter = THREE.LinearFilter;
+      texture.magFilter = THREE.LinearFilter;
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.needsUpdate = true;
+      return texture;
+    } catch {
+      // ImageBitmap 디코딩 실패 → 폴백.
+    }
+  }
+
+  // 2) 폴백 — 표준 TextureLoader.
+  return new Promise((resolve) => {
+    const loader = new THREE.TextureLoader();
+    loader.crossOrigin = 'anonymous';
+    loader.load(
+      url,
+      (texture) => {
+        texture.minFilter = THREE.LinearFilter;
+        texture.magFilter = THREE.LinearFilter;
+        texture.colorSpace = THREE.SRGBColorSpace;
+        resolve(texture);
+      },
+      undefined,
+      () => resolve(null),
+    );
+  });
+}

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -4,6 +4,7 @@ import type { Block, PlaceBlockData, PlacesBlock, CourseBlock, EventsBlock, Even
 import { getWelcomeMessage } from '@/mocks/agent-responses';
 import { openChatStream } from '@/lib/sse';
 import { chatsApi } from '@/lib/api';
+import { prefetchCourse3D } from '@/lib/prefetch-3d';
 import { friendlyApiError } from '@/lib/auth-errors';
 import { normalizeCategory } from '@/lib/utils';
 import { useMapStore } from './mapStore';
@@ -279,6 +280,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
             itineraries.push(it);
             // 단수 필드는 첫 번째 코스로 유지 (기존 코드 호환).
             if (!itinerary) itinerary = it;
+            // 백그라운드 prefetch — 사용자가 3D 보기 토글하기 전 미리 데이터/모듈 준비.
+            prefetchCourse3D(it.stops);
           }
         },
         // 그 외 블록은 그대로 message.blocks에 보존 → BlockRenderer가 렌더.


### PR DESCRIPTION
## 작업 내용
Phase 1 의 빌드/마커 최적화 이후 네트워크/모듈 레이어 개선.

### 1. OSM 타일 영구 캐시 (`lib/tile-cache.ts` 신규)
- Cache Storage (Cache API) 에 fetch 응답 영구 보관
- `loadTileTexture(url)`: cache.match → 미스 시 fetch + cache.put → blob → ImageBitmap → THREE.Texture
- ImageBitmap 사용으로 blob URL 라이프사이클 이슈 회피
- Cache API / createImageBitmap 미지원 환경에선 표준 TextureLoader 자동 폴백
- `three-scene.ts` `loadGround` 가 이 로더 사용

**효과**: 두 번째 3D 진입부터 ground 타일 1-3s → 즉시 표시.

### 2. Eager prefetch on intent (`lib/prefetch-3d.ts` 신규)
- 채팅 SSE 가 `course` 블록 보내는 순간 백그라운드로:
  - (a) ThreeMap React.lazy chunk 다운로드
  - (b) 각 stop 좌표 `fetchBuildingsNearPoint` → IndexedDB 캐시 적재
- `prefetchInFlight` 가드로 중복 방지
- `chatStore.send` 의 course 핸들러에서 fire-and-forget 호출

**효과**: 사용자가 "3D 보기" 토글하기 전에 데이터/모듈 준비 완료 → 클릭 → 표시 사이 대기 시간 0 에 수렴.

### Deferred (Phase 2 잔여)
- **정적 자치구 JSON ship** — 이 환경에서 Overpass 접근 막혀 데이터 생성 불가. 빌드 스크립트(`scripts/build-district-buildings.mjs`) 는 이미 준비됨. 외부 환경에서 실행 후 `STATIC_DISTRICT_LOADERS` 등록만 하면 자동 활성화.

### 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)