### PR TITLE
feat: 일정 탭 Google Calendar 연동 + 이미지 검색 업로드 UI

### DIFF
--- a/src/components/calendar/CalendarPanel.tsx
+++ b/src/components/calendar/CalendarPanel.tsx
@@ -1,13 +1,12 @@
-import { useState } from 'react';
-import { Calendar, Download, Link2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Calendar, Link2, ExternalLink, MapPin, AlertCircle } from 'lucide-react';
 import { useCalendarStore } from '@/stores/calendarStore';
-import { TRANSPORT_LABELS } from '@/lib/utils';
-import { downloadICS } from '@/lib/ics-export';
+import { useAuthStore } from '@/stores/authStore';
 import { googleCalendarApi } from '@/lib/api';
 import { friendlyApiError } from '@/lib/auth-errors';
 import { toast } from '@/stores/toastStore';
 import EmptyState from '@/components/ui/EmptyState';
-import type { Itinerary } from '@/types';
+import type { CalendarEventItem } from '@/types/api';
 
 function GoogleCalendarConnectBar() {
   const [busy, setBusy] = useState(false);
@@ -36,15 +35,160 @@ function GoogleCalendarConnectBar() {
   );
 }
 
+function NotConnectedPanel() {
+  return (
+    <div className="h-full flex flex-col">
+      <GoogleCalendarConnectBar />
+      <div className="flex-1 flex items-center justify-center">
+        <EmptyState
+          icon={Link2}
+          title="Google Calendar 연동 필요"
+          description="연동하면 에이전트가 만든 일정이 여기에 표시됩니다"
+          lottieSrc="/animations/calender.json"
+        />
+      </div>
+    </div>
+  );
+}
+
+function formatTimeRange(start: string | null, end: string | null): string {
+  if (!start) return '시간 정보 없음';
+  const s = new Date(start);
+  const startStr = s.toLocaleString('ko-KR', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  if (!end) return startStr;
+  const e = new Date(end);
+  const sameDay = s.toDateString() === e.toDateString();
+  const endStr = sameDay
+    ? e.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
+    : e.toLocaleString('ko-KR', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  return `${startStr} ~ ${endStr}`;
+}
+
+function EventCard({ event }: { event: CalendarEventItem }) {
+  const removeEvent = useCalendarStore((s) => s.removeEvent);
+  const isLocalBiz = event.source === 'localbiz';
+
+  return (
+    <div className="bg-bg-surface border border-border rounded-2xl overflow-hidden">
+      <div className="px-4 py-3 border-b border-border bg-bg-subtle/50">
+        <div className="flex items-center justify-between gap-2 mb-1">
+          <h3 className="text-[14px] font-semibold text-text-primary tracking-[-0.02em] flex-1 truncate">
+            {event.title || '제목 없음'}
+          </h3>
+          {isLocalBiz && (
+            <span className="shrink-0 text-[10px] font-medium px-2 py-0.5 rounded-full bg-brand-subtle text-brand">
+              LocalBiz
+            </span>
+          )}
+        </div>
+        <div className="text-[11px] text-text-muted tabular-nums">
+          {formatTimeRange(event.start_time, event.end_time)}
+        </div>
+      </div>
+      <div className="px-4 py-3 space-y-2">
+        {event.location && (
+          <div className="flex items-start gap-1.5 text-[12px] text-text-secondary">
+            <MapPin size={12} className="mt-0.5 shrink-0 text-text-muted" />
+            <span className="line-clamp-2">{event.location}</span>
+          </div>
+        )}
+        {event.description && (
+          <p className="text-[12px] text-text-secondary line-clamp-3 whitespace-pre-line">
+            {event.description}
+          </p>
+        )}
+      </div>
+      <div className="flex border-t border-border">
+        {event.calendar_link && (
+          <a
+            href={event.calendar_link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 flex items-center justify-center gap-1.5 py-2.5 text-[12px] font-medium text-brand hover:bg-brand-subtle transition-colors cursor-pointer border-r border-border"
+          >
+            <ExternalLink size={12} />
+            캘린더 열기
+          </a>
+        )}
+        <button
+          onClick={() => removeEvent(event.event_id)}
+          className="flex-1 py-2.5 text-[12px] font-medium text-text-muted hover:bg-[#FEF2F2] hover:text-[#DC2626] transition-colors cursor-pointer"
+        >
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function CalendarPanel() {
-  const { events, removeEvent } = useCalendarStore();
+  const events = useCalendarStore((s) => s.events);
+  const loading = useCalendarStore((s) => s.loading);
+  const error = useCalendarStore((s) => s.error);
+  const notConnected = useCalendarStore((s) => s.notConnected);
+  const loadFromServer = useCalendarStore((s) => s.loadFromServer);
+  const authToken = useAuthStore((s) => s.token);
+
+  useEffect(() => {
+    if (!authToken) return;
+    loadFromServer();
+  }, [authToken, loadFromServer]);
+
+  if (!authToken) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <EmptyState
+          icon={Calendar}
+          title="로그인 필요"
+          description="로그인하면 일정이 여기에 표시됩니다"
+        />
+      </div>
+    );
+  }
+
+  if (notConnected) {
+    return <NotConnectedPanel />;
+  }
+
+  if (loading && events.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="w-5 h-5 border-2 border-brand/30 border-t-brand rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="h-full flex flex-col">
+        <GoogleCalendarConnectBar />
+        <div className="flex-1 flex items-center justify-center px-6">
+          <div className="text-center">
+            <AlertCircle size={28} className="mx-auto mb-2 text-[#DC2626]" />
+            <p className="text-[13px] text-text-secondary mb-3">{error}</p>
+            <button
+              onClick={loadFromServer}
+              className="px-3 py-1.5 rounded-lg border border-border text-[12px] text-text-primary hover:bg-bg-subtle cursor-pointer"
+            >
+              다시 시도
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (events.length === 0) {
     return (
       <div className="h-full flex flex-col">
         <GoogleCalendarConnectBar />
         <div className="flex-1 flex items-center justify-center">
-          <EmptyState icon={Calendar} title="일정 없음" description="에이전트에게 일정을 만들어달라고 해보세요" lottieSrc="/animations/calender.json" />
+          <EmptyState
+            icon={Calendar}
+            title="일정 없음"
+            description="에이전트에게 일정을 만들어달라고 해보세요"
+            lottieSrc="/animations/calender.json"
+          />
         </div>
       </div>
     );
@@ -52,45 +196,8 @@ export default function CalendarPanel() {
 
   return (
     <div className="h-full overflow-y-auto p-3 space-y-3">
-      <GoogleCalendarConnectBar />
       {events.map((event) => (
-        <div key={event.id} className="bg-bg-surface border border-border rounded-2xl overflow-hidden animate-fade-up">
-          <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-bg-subtle/50">
-            <h3 className="text-[14px] font-semibold text-text-primary tracking-[-0.02em]">{event.title}</h3>
-            <div className="flex items-center gap-2">
-              <span className="text-[11px] text-text-muted">{event.date}</span>
-              <button onClick={() => removeEvent(event.id)} className="text-[11px] text-text-muted hover:text-[#DC2626] transition-colors cursor-pointer">삭제</button>
-            </div>
-          </div>
-          <div className="px-4 py-2">
-            {event.stops.map((stop, i) => (
-              <div key={stop.order}>
-                <div className="flex items-center gap-3 py-2">
-                  <span className="text-[12px] text-text-muted w-10 shrink-0 tabular-nums font-medium">{stop.arrivalTime}</span>
-                  <span className="relative w-2 h-2 rounded-full bg-brand shrink-0">
-                    {i < event.stops.length - 1 && <span className="absolute top-2 left-1/2 -translate-x-1/2 w-px h-7 bg-border" />}
-                  </span>
-                  <span className="text-[12px] text-text-primary font-medium">{stop.placeName}</span>
-                  <span className="text-[11px] text-text-muted ml-auto tabular-nums">{stop.duration}분</span>
-                </div>
-                {i < event.stops.length - 1 && stop.travelTimeToNext > 0 && (
-                  <div className="pl-[68px] pb-0.5">
-                    <span className="text-[11px] text-text-muted">{TRANSPORT_LABELS[stop.transportToNext].icon} {stop.travelTimeToNext}분</span>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-          <div className="border-t border-border">
-            <button
-              onClick={() => downloadICS({ id: event.id, title: event.title, date: event.date, stops: event.stops } as Itinerary)}
-              className="w-full flex items-center justify-center gap-1.5 py-2.5 text-[12px] font-medium text-brand hover:bg-brand-subtle transition-colors cursor-pointer"
-            >
-              <Download size={12} />
-              캘린더에 추가
-            </button>
-          </div>
-        </div>
+        <EventCard key={event.event_id} event={event} />
       ))}
     </div>
   );

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,6 +1,9 @@
-import { memo, useState, useRef, type FormEvent, type KeyboardEvent } from 'react';
-import { ArrowUp } from 'lucide-react';
+import { memo, useState, useRef, useEffect, type FormEvent, type KeyboardEvent, type ChangeEvent } from 'react';
+import { ArrowUp, Image as ImageIcon, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { uploadApi } from '@/lib/api';
+import { friendlyApiError } from '@/lib/auth-errors';
+import { toast } from '@/stores/toastStore';
 
 interface ChatInputProps {
   onSend: (text: string) => void;
@@ -15,15 +18,73 @@ const EXAMPLE_CHIPS = [
   '한강 근처 맛집 알려줘',
 ];
 
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_BYTES = 10 * 1024 * 1024;
+
 export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInputProps) {
   const [text, setText] = useState('');
   const [focused, setFocused] = useState(false);
+  const [attachedImage, setAttachedImage] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleSubmit = (e: FormEvent) => {
+  // 미리보기 blob URL 정리 — 컴포넌트 언마운트 또는 이미지 교체 시 메모리 회수.
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ''; // 같은 파일 재선택 가능하도록 리셋
+    if (!file) return;
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      toast.error('jpg, png, webp 파일만 첨부 가능합니다');
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      toast.error('10MB 이하 사진만 첨부 가능합니다');
+      return;
+    }
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(URL.createObjectURL(file));
+    setAttachedImage(file);
+  };
+
+  const clearImage = () => {
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(null);
+    setAttachedImage(null);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (!text.trim() || disabled) return;
-    onSend(text.trim());
+    if (disabled || uploading) return;
+    const trimmed = text.trim();
+    if (!trimmed && !attachedImage) return;
+
+    let finalText = trimmed;
+    if (attachedImage) {
+      setUploading(true);
+      try {
+        const { image_url } = await uploadApi.image(attachedImage);
+        // BE image_search_node 가 query 텍스트에서 https URL 을 regex 로 추출.
+        finalText = trimmed
+          ? `${trimmed}\n${image_url}`
+          : `이 사진과 비슷한 곳 추천해줘\n${image_url}`;
+      } catch (err) {
+        toast.error(friendlyApiError(err, '사진 업로드 실패'));
+        setUploading(false);
+        return;
+      }
+      setUploading(false);
+      clearImage();
+    }
+
+    onSend(finalText);
     setText('');
   };
 
@@ -34,7 +95,7 @@ export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInpu
     }
   };
 
-  const canSend = text.trim() && !disabled;
+  const canSend = (text.trim().length > 0 || attachedImage !== null) && !disabled && !uploading;
 
   return (
     <div className="px-4 pb-4 pt-2 shrink-0">
@@ -51,15 +112,58 @@ export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInpu
           ))}
         </div>
       )}
+
+      {previewUrl && (
+        <div className="mb-2 inline-flex items-center gap-2 bg-bg-surface border border-border rounded-xl p-1.5">
+          <div className="relative w-14 h-14 rounded-lg overflow-hidden bg-bg-subtle">
+            <img src={previewUrl} alt="첨부 사진" className="w-full h-full object-cover" />
+            {uploading && (
+              <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                <div className="w-4 h-4 border-2 border-white/60 border-t-white rounded-full animate-spin" />
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col items-start gap-1 pr-1">
+            <span className="text-[11px] text-text-muted">사진 1장</span>
+            <button
+              type="button"
+              onClick={clearImage}
+              disabled={uploading}
+              className="inline-flex items-center gap-1 text-[11px] text-text-muted hover:text-[#DC2626] cursor-pointer disabled:opacity-50"
+            >
+              <X size={12} /> 제거
+            </button>
+          </div>
+        </div>
+      )}
+
       <form onSubmit={handleSubmit}>
         <div
           className={cn(
-            'flex items-center gap-2 bg-bg-surface rounded-[14px] pl-4 pr-1.5 py-1.5 transition-all duration-200',
+            'flex items-center gap-1 bg-bg-surface rounded-[14px] pl-2 pr-1.5 py-1.5 transition-all duration-200',
             focused
               ? 'border-2 border-brand/40 shadow-focus'
               : 'border border-border shadow-sm hover:border-border-strong',
           )}
         >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            capture="environment"
+            onChange={handleFileChange}
+            className="hidden"
+            aria-label="사진 첨부"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled || uploading}
+            className="w-8 h-8 rounded-lg flex items-center justify-center text-text-muted hover:text-brand hover:bg-brand-subtle cursor-pointer disabled:opacity-40 transition-colors"
+            aria-label="사진 첨부"
+          >
+            <ImageIcon size={16} strokeWidth={1.8} />
+          </button>
           <input
             ref={inputRef}
             type="text"
@@ -68,10 +172,10 @@ export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInpu
             onKeyDown={handleKeyDown}
             onFocus={() => setFocused(true)}
             onBlur={() => setFocused(false)}
-            placeholder="서울에서 무엇을 하고 싶으세요?"
+            placeholder={attachedImage ? '사진과 함께 보낼 메시지 (선택)' : '서울에서 무엇을 하고 싶으세요?'}
             disabled={disabled}
             className={cn(
-              'flex-1 bg-transparent border-none outline-none text-[14px] text-text-primary',
+              'flex-1 bg-transparent border-none outline-none text-[14px] text-text-primary px-1',
               'placeholder:text-text-muted leading-[1.5] min-w-0',
               disabled && 'opacity-40',
             )}
@@ -86,9 +190,13 @@ export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInpu
                 ? 'bg-brand text-white shadow-xs hover:bg-brand-hover active:scale-95'
                 : 'bg-bg-subtle text-text-muted',
             )}
-            aria-label="전송"
+            aria-label={uploading ? '업로드 중' : '전송'}
           >
-            <ArrowUp size={15} strokeWidth={2.5} />
+            {uploading ? (
+              <div className="w-3.5 h-3.5 border-2 border-white/60 border-t-white rounded-full animate-spin" />
+            ) : (
+              <ArrowUp size={15} strokeWidth={2.5} />
+            )}
           </button>
         </div>
       </form>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   PlaceBookmarkCreateRequest,
   PlaceBookmarkItem,
   PlaceBookmarkListResponse,
+  CalendarEventsResponse,
+  ImageUploadResponse,
   ChatDetailResponse,
   ChatListResponse,
   FeedbackRequest,
@@ -275,6 +277,27 @@ export const placeBookmarksApi = {
     }),
   delete: (bookmark_id: number) =>
     request<void>(`/api/v1/users/me/place-bookmarks/${bookmark_id}`, { method: 'DELETE' }),
+};
+
+// Google Calendar 이벤트 직조회 (BE Phase 1 — DB 미저장, Google source of truth).
+// 미연동 시 403 { detail: "google_calendar_not_connected" }.
+export const calendarApi = {
+  listEvents: (params?: { time_min?: string; time_max?: string; limit?: number; page_token?: string }) =>
+    request<CalendarEventsResponse>(buildUrl('/api/v1/users/me/calendar/events', params)),
+  deleteEvent: (event_id: string) =>
+    request<void>(`/api/v1/users/me/calendar/events/${encodeURIComponent(event_id)}`, { method: 'DELETE' }),
+};
+
+// 이미지 업로드 — GCS 임시 저장 후 1시간짜리 signed URL 반환.
+export const uploadApi = {
+  image: (file: File) => {
+    const fd = new FormData();
+    fd.append('file', file);
+    return request<ImageUploadResponse>('/api/v1/upload/image', {
+      method: 'POST',
+      body: fd,
+    });
+  },
 };
 
 export const chatsApi = {

--- a/src/stores/calendarStore.ts
+++ b/src/stores/calendarStore.ts
@@ -1,33 +1,63 @@
 import { create } from 'zustand';
-import type { CalendarEvent, Itinerary } from '@/types';
+import type { CalendarEventItem } from '@/types/api';
+import { calendarApi } from '@/lib/api';
+import { friendlyApiError } from '@/lib/auth-errors';
+
+// 일정 탭 — Google Calendar 직조회 결과 보관. BE Phase 1 (PR 캘린더).
+// 우리 DB 미저장. 새로고침/다른 기기/외부 수정 모두 Google 이 source of truth.
 
 interface CalendarStore {
-  events: CalendarEvent[];
-  selectedDate: string;
+  events: CalendarEventItem[];
+  loading: boolean;
+  error: string | null;
+  // BE 403 (google_calendar_not_connected) — FE 가 연동 CTA 강조용으로 사용.
+  notConnected: boolean;
 
-  addEvent: (itinerary: Itinerary) => void;
-  removeEvent: (id: string) => void;
-  setSelectedDate: (date: string) => void;
+  loadFromServer: () => Promise<void>;
+  removeEvent: (event_id: string) => Promise<void>;
 }
 
-export const useCalendarStore = create<CalendarStore>((set) => ({
-  events: [],
-  selectedDate: new Date().toISOString().split('T')[0],
+// BE 403 body { "detail": "google_calendar_not_connected" } → ApiHttpError 의
+// status=403, message="google_calendar_not_connected" 로 변환되어 throw.
+function isNotConnectedError(e: unknown): boolean {
+  if (!e || typeof e !== 'object') return false;
+  const anyE = e as { status?: number; message?: string };
+  return anyE.status === 403 && anyE.message === 'google_calendar_not_connected';
+}
 
-  addEvent: (itinerary) => {
-    const event: CalendarEvent = {
-      id: `event-${Date.now()}`,
-      title: itinerary.title,
-      date: itinerary.date,
-      stops: itinerary.stops,
-      createdAt: new Date().toISOString(),
-      source: 'agent',
-    };
-    set((state) => ({ events: [...state.events, event] }));
+export const useCalendarStore = create<CalendarStore>((set, get) => ({
+  events: [],
+  loading: false,
+  error: null,
+  notConnected: false,
+
+  loadFromServer: async () => {
+    set({ loading: true, error: null });
+    try {
+      const res = await calendarApi.listEvents({ limit: 50 });
+      set({ events: res.items, loading: false, notConnected: false });
+    } catch (e) {
+      if (isNotConnectedError(e)) {
+        // 미연동은 정상 상태 — error 가 아니라 notConnected 플래그로 분리.
+        set({ events: [], loading: false, notConnected: true, error: null });
+        return;
+      }
+      set({
+        loading: false,
+        error: friendlyApiError(e, '일정을 불러올 수 없습니다'),
+      });
+    }
   },
 
-  removeEvent: (id) =>
-    set((state) => ({ events: state.events.filter((e) => e.id !== id) })),
-
-  setSelectedDate: (date) => set({ selectedDate: date }),
+  removeEvent: async (event_id) => {
+    const prev = get().events;
+    // Optimistic 제거.
+    set({ events: prev.filter((e) => e.event_id !== event_id) });
+    try {
+      await calendarApi.deleteEvent(event_id);
+    } catch {
+      // 롤백 — BE 실패 시 다음 loadFromServer 에서 진실 복원되지만 즉시 되돌림.
+      set({ events: prev });
+    }
+  },
 }));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -92,6 +92,31 @@ export type PlaceBookmarkListResponse = {
   next_cursor: string | null;
 };
 
+// === Calendar Events (BE Phase 1 — Google Calendar 직접 조회) ===
+export type CalendarEventSource = 'localbiz' | 'user';
+
+export type CalendarEventItem = {
+  event_id: string;
+  title: string;
+  start_time: string | null;
+  end_time: string | null;
+  location: string | null;
+  description: string | null;
+  calendar_link: string | null;
+  source: CalendarEventSource;
+};
+
+export type CalendarEventsResponse = {
+  items: CalendarEventItem[];
+  next_page_token: string | null;
+};
+
+// === Image Upload ===
+export type ImageUploadResponse = {
+  image_url: string;
+  expires_in_seconds: number;
+};
+
 // === Chats ===
 export type ChatListItem = {
   thread_id: string;


### PR DESCRIPTION
## 작업 내용
BE 가 새로 추가한 두 API 와 연동.

### 1. 캘린더 일정 탭 — Google Calendar 직조회
**BE 신규 엔드포인트** (Option B 채택):
- `GET /api/v1/users/me/calendar/events` — 사용자 Google Calendar 직조회, DB 미저장
- `DELETE /api/v1/users/me/calendar/events/{event_id}` — Google 에서 직접 삭제
- 미연동 시 403 `{ detail: "google_calendar_not_connected" }`

**FE 변경**:
- `types/api.ts`: `CalendarEventItem`, `CalendarEventsResponse`
- `lib/api.ts`: `calendarApi.{listEvents, deleteEvent}`
- `stores/calendarStore.ts`: 전면 재작성. 4상태 (events/loading/error/notConnected). 403 은 error 가 아니라 notConnected 플래그로 분기.
- `components/calendar/CalendarPanel.tsx`:
  - 비로그인 / notConnected (연동 CTA 강조) / loading / error (재시도) / empty / populated
  - 카드: title / 시간 range / location / description / 캘린더 열기 / 삭제
  - **LocalBiz 배지** — `source==='localbiz'` 이벤트(우리 앱이 만든 것)는 작은 배지 표시

### 2. 이미지 검색 업로드 UI
**BE 신규 엔드포인트** (Option A — GCS 호스팅):
- `POST /api/v1/upload/image` (multipart) → `{ image_url, expires_in_seconds: 3600 }`
- jpg/png/webp, 10MB 이하

**FE 변경**:
- `lib/api.ts`: `uploadApi.image(file)`
- `components/chat/ChatInput.tsx`:
  - 이미지 아이콘 버튼 → 파일 picker (`accept=image/*`, `capture=environment` 로 모바일 카메라 직접)
  - 클라이언트 검증 (서버 검증과 동일 — 422 전에 토스트로 차단)
  - 미리보기 thumbnail + 제거 버튼
  - 전송 시: upload → URL 받음 → query 본문에 `"\n{url}"` 추가 (BE `image_search_node` 가 regex 파싱)
  - 텍스트 없이 사진만 → `"이 사진과 비슷한 곳 추천해줘\n{url}"` 자동 prefix
  - 업로드 중 send 버튼 spinner, 다른 입력 disable
  - blob URL 정리 (cleanup effect)

### 검증
- typecheck 0 errors
- 13/13 tests pass

### 관련 BE PRs
- `backend/src/api/calendar.py` 신규
- `backend/src/api/upload.py` 신규 (feat/#103)

🤖 Generated with [Claude Code](https://claude.com/claude-code)