### PR TITLE
fix: 폴리라인 즐겨찾기 제외 + 사이드바 액션 아이콘 모바일 노출

### DIFF
--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -314,14 +314,14 @@ function SessionItem({ session, isActive, onLoad, onDelete, onRename }: SessionI
         <div className="flex items-center gap-0.5 shrink-0 mt-0.5">
           <button
             onClick={(e) => { e.stopPropagation(); setEditing(true); }}
-            className="opacity-0 group-hover:opacity-100 w-6 h-6 rounded-md flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-all cursor-pointer"
+            className="w-6 h-6 rounded-md flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-all cursor-pointer"
             aria-label="대화 제목 편집"
           >
             <Pencil size={12} />
           </button>
           <button
             onClick={(e) => { e.stopPropagation(); onDelete(session.id); }}
-            className="opacity-0 group-hover:opacity-100 w-6 h-6 rounded-md flex items-center justify-center text-text-muted hover:text-[#DC2626] hover:bg-[#FEF2F2] transition-all cursor-pointer"
+            className="w-6 h-6 rounded-md flex items-center justify-center text-text-muted hover:text-[#DC2626] hover:bg-[#FEF2F2] transition-all cursor-pointer"
             aria-label="대화 삭제"
           >
             <Trash2 size={12} />

--- a/src/components/map/GoogleMap.tsx
+++ b/src/components/map/GoogleMap.tsx
@@ -283,8 +283,11 @@ export default function GoogleMap({
 
       // 코스(itineraryMode)일 때만 마커 간 경로선을 그림.
       // 장소/행사 추천처럼 독립된 장소 목록에는 선을 연결하지 않음.
-      if (itineraryMode && markers.length > 1) {
-        const path = markers.map((p) => ({ lat: p.lat, lng: p.lng }));
+      // 즐겨찾기(isBookmark)는 코스와 무관한 별도 핀이라 경로에서 제외 — 안 그러면
+      // 폴리라인이 즐겨찾기 위치까지 이어져 코스가 어지럽게 보임.
+      const routeMarkers = markers.filter((p) => !p.isBookmark);
+      if (itineraryMode && routeMarkers.length > 1) {
+        const path = routeMarkers.map((p) => ({ lat: p.lat, lng: p.lng }));
         polylineRef.current = new google.maps.Polyline({
           path,
           strokeWeight: 7,


### PR DESCRIPTION
## 작업 내용

### 1. 코스 폴리라인 즐겨찾기 제외
**증상**: 즐겨찾기 해둔 장소가 있을 때 코스 추천 받으면, 폴리라인이 코스 stop 들과 무관하게 즐겨찾기 위치까지 갈지자로 이어짐.

**원인**: `GoogleMap.tsx:286` 가 `itineraryMode` 일 때 `markers` 전체(즐겨찾기 포함)를 path 로 사용.

**수정**: `routeMarkers = markers.filter(p => !p.isBookmark)` 로 분리. 폴리라인은 코스 stop 만으로 그림. 즐겨찾기는 핀만 그대로.

### 2. 사이드바 edit/delete 아이콘 모바일 노출
**증상**: 대화 목록의 edit/삭제 아이콘이 hover 시에만 보여서 모바일 웹앱에서 영영 안 보임.

**원인**: `opacity-0 group-hover:opacity-100` 클래스 — hover 가 없는 모바일에선 영구 hidden.

**수정**: 해당 클래스 제거. 항상 노출.

### 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)