### PR TITLE
feat(3d): stop 좌표 빌딩 강조 — target 빨강 + 주변 N개 파랑

### DIFF
--- a/src/components/map/MapPanel.tsx
+++ b/src/components/map/MapPanel.tsx
@@ -64,6 +64,8 @@ export default function MapPanel() {
 
   // Route panel visibility — toggled by the "경로" button. Auto-opens when a new itinerary begins.
   const [routePanelOpen, setRoutePanelOpen] = useState(true);
+  // 3D 강조 모드 — target 빌딩 + 주변 N개. 5/10/15 토글.
+  const [neighborCount, setNeighborCount] = useState<5 | 10 | 15>(10);
   const navId = navigation?.itinerary.id ?? null;
   useEffect(() => { if (navId) setRoutePanelOpen(true); }, [navId]);
   const closeRoutePanel = useCallback(() => setRoutePanelOpen(false), []);
@@ -123,6 +125,7 @@ export default function MapPanel() {
                     onBuildingCount={handleBuildingCount}
                     onError={handleError}
                     navigation={navigation}
+                    neighborCount={neighborCount}
                   />
                 </Suspense>
               ) : (
@@ -167,6 +170,26 @@ export default function MapPanel() {
                     <Route size={14} aria-hidden="true" />
                     경로
                   </button>
+                )}
+                {is3D && navigation && (
+                  <div className="flex items-center gap-1 bg-white border border-border rounded-xl shadow-md px-1.5 py-1">
+                    <span className="text-[11px] font-medium text-text-muted px-1.5">주변</span>
+                    {([5, 10, 15] as const).map((n) => (
+                      <button
+                        key={n}
+                        onClick={() => setNeighborCount(n)}
+                        className={`px-2 py-1 rounded-lg text-[12px] font-semibold transition-colors cursor-pointer tabular-nums ${
+                          neighborCount === n
+                            ? 'bg-brand text-white'
+                            : 'text-text-secondary hover:bg-bg-subtle'
+                        }`}
+                        aria-pressed={neighborCount === n}
+                        aria-label={`주변 ${n}개`}
+                      >
+                        {n}
+                      </button>
+                    ))}
+                  </div>
                 )}
                 <button
                   onClick={() => { setIs3D(!is3D); setError3D(null); }}

--- a/src/components/map/ThreeMap.tsx
+++ b/src/components/map/ThreeMap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { MapScene3D } from '@/lib/three-scene';
 import { fetchBuildingsNearPoint } from '@/lib/overpass';
+import { pickFocusBuildings } from '@/lib/focus-buildings';
 import type { Place } from '@/types';
 import { useMapStore } from '@/stores/mapStore';
 import type { NavigationState } from '@/stores/mapStore';
@@ -16,6 +17,8 @@ interface ThreeMapProps {
   onBuildingCount: (count: number) => void;
   onError: (msg: string) => void;
   navigation?: NavigationState | null;
+  // 강조 모드 — target 1개(빨강) + neighbors N개(파랑). default 10.
+  neighborCount?: number;
 }
 
 export default function ThreeMap({
@@ -27,6 +30,7 @@ export default function ThreeMap({
   onBuildingCount,
   onError,
   navigation,
+  neighborCount = 10,
 }: ThreeMapProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const sceneRef = useRef<MapScene3D | null>(null);
@@ -153,15 +157,23 @@ export default function ThreeMap({
     if (prevStopBuildingRef.current !== navStopIndex) {
       prevStopBuildingRef.current = navStopIndex;
       const coord = stopCoords[navStopIndex];
+      const stop = navigation.itinerary.stops[navStopIndex];
       if (coord) {
         fetchBuildingsNearPoint(coord.lat, coord.lng, 500).then((buildings) => {
           if (!sceneRef.current) return;
-          sceneRef.current.transitionBuildings(buildings, { lat: coord.lat, lon: coord.lng });
-          onBuildingCount(buildings.length);
+          // 강조 모드 — target(빨강) + neighborCount 개 neighbors(파랑) 만 렌더.
+          const focused = pickFocusBuildings(buildings, coord, neighborCount);
+          sceneRef.current.transitionFocusedBuildings(
+            focused.target,
+            focused.neighbors,
+            { lat: coord.lat, lon: coord.lng },
+            stop?.placeName,
+          );
+          onBuildingCount(focused.neighbors.length + (focused.target ? 1 : 0));
         });
       }
     }
-  }, [navId, navStopIndex, navigation, markers, onBuildingCount, center.lat, center.lng]);
+  }, [navId, navStopIndex, navigation, markers, onBuildingCount, center.lat, center.lng, neighborCount]);
 
   // Auto-play: advance stops when isPlaying (primitive deps)
   useEffect(() => {

--- a/src/lib/focus-buildings.ts
+++ b/src/lib/focus-buildings.ts
@@ -1,0 +1,89 @@
+// 코스 stop 좌표 1개 + 그 주변 빌딩 N개 만 강조 렌더할 때 사용.
+// target = 좌표가 footprint 안에 들어가는 빌딩 (없으면 centroid 최단거리 fallback).
+// neighbors = target 제외, centroid 가 좌표에서 가까운 순으로 N개.
+
+import type { BuildingData } from './overpass';
+
+export interface FocusedBuildings {
+  target: BuildingData | null;
+  neighbors: BuildingData[];
+}
+
+// Ray casting point-in-polygon. ring 은 [[lat, lng], ...] 순서.
+function pointInPolygon(lat: number, lng: number, ring: [number, number][]): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [yi, xi] = ring[i];
+    const [yj, xj] = ring[j];
+    const intersect = (yi > lat) !== (yj > lat) &&
+      lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+function centroid(ring: [number, number][]): { lat: number; lng: number } {
+  let lat = 0;
+  let lng = 0;
+  for (const [la, ln] of ring) {
+    lat += la;
+    lng += ln;
+  }
+  return { lat: lat / ring.length, lng: lng / ring.length };
+}
+
+// 짧은 거리 비교 용도라 Haversine 대신 flat earth 근사 (서울 위도 기준).
+// 비교 sort 만 필요해서 단위(m) 정확성보다 일관성 우선.
+function squaredDist(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const COS = Math.cos((lat1 * Math.PI) / 180);
+  const dLat = (lat2 - lat1) * 111320;
+  const dLng = (lng2 - lng1) * 111320 * COS;
+  return dLat * dLat + dLng * dLng;
+}
+
+export function pickFocusBuildings(
+  buildings: BuildingData[],
+  coord: { lat: number; lng: number },
+  neighborCount = 10,
+): FocusedBuildings {
+  if (buildings.length === 0) return { target: null, neighbors: [] };
+
+  // 1) Polygon 포함 매치
+  let target: BuildingData | null = null;
+  for (const b of buildings) {
+    if (b.coords.length >= 3 && pointInPolygon(coord.lat, coord.lng, b.coords)) {
+      target = b;
+      break;
+    }
+  }
+
+  // 2) Fallback — centroid 가장 가까운 빌딩
+  if (!target) {
+    let bestDist = Infinity;
+    for (const b of buildings) {
+      if (b.coords.length < 3) continue;
+      const c = centroid(b.coords);
+      const d = squaredDist(coord.lat, coord.lng, c.lat, c.lng);
+      if (d < bestDist) {
+        bestDist = d;
+        target = b;
+      }
+    }
+  }
+
+  if (!target) return { target: null, neighbors: [] };
+
+  // 3) 나머지 → centroid 거리 sort → top N
+  const targetRef = target;
+  const others = buildings
+    .filter((b) => b !== targetRef && b.coords.length >= 3)
+    .map((b) => {
+      const c = centroid(b.coords);
+      return { b, d: squaredDist(coord.lat, coord.lng, c.lat, c.lng) };
+    })
+    .sort((a, b) => a.d - b.d)
+    .slice(0, neighborCount)
+    .map((x) => x.b);
+
+  return { target, neighbors: others };
+}

--- a/src/lib/three-scene.ts
+++ b/src/lib/three-scene.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { CSS2DRenderer, CSS2DObject } from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 import type { BuildingData } from './overpass';
 import { loadTileTexture } from './tile-cache';
 import type { Place } from '@/types';
@@ -47,6 +48,9 @@ export class MapScene3D {
   private gpsMarker: THREE.Group | null = null;
   // loadBuildings 가 async chunked 라 직전 호출을 cancel 하기 위한 세대 counter.
   private buildGeneration = 0;
+  // CSS2DRenderer — target 빌딩 라벨용 DOM 오버레이.
+  private labelRenderer: CSS2DRenderer;
+  private focusLabel: CSS2DObject | null = null;
   private running = false;
   private renderRequested = false;
   private dampingFrames = 0;
@@ -106,6 +110,16 @@ export class MapScene3D {
 
     this.scene.add(new THREE.DirectionalLight(0x8ecae6, 0.3).translateX(-300).translateY(200).translateZ(-200));
     this.scene.add(new THREE.HemisphereLight(0xb8d4e8, 0x444444, 0.4));
+
+    // CSS2DRenderer — WebGL 위에 DOM 오버레이로 라벨 표시. canvas 부모에 absolute 로 얹음.
+    this.labelRenderer = new CSS2DRenderer();
+    this.labelRenderer.setSize(canvas.clientWidth, canvas.clientHeight);
+    const labelEl = this.labelRenderer.domElement;
+    labelEl.style.position = 'absolute';
+    labelEl.style.top = '0';
+    labelEl.style.left = '0';
+    labelEl.style.pointerEvents = 'none';
+    canvas.parentElement?.appendChild(labelEl);
 
     this.requestRender = this.requestRender.bind(this);
   }
@@ -706,6 +720,7 @@ export class MapScene3D {
       if (!this.running) return;
       this.controls.update();
       this.renderer.render(this.scene, this.camera);
+      this.labelRenderer.render(this.scene, this.camera);
       // Continue rendering for damping ease-out
       if (this.dampingFrames > 0) {
         this.dampingFrames--;
@@ -718,6 +733,7 @@ export class MapScene3D {
     this.camera.aspect = w / h;
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(w, h);
+    this.labelRenderer.setSize(w, h);
     this.requestRender();
   }
 
@@ -736,5 +752,198 @@ export class MapScene3D {
     }
     this.controls.dispose();
     this.renderer.dispose();
+    this.clearFocusLabel();
+    this.labelRenderer.domElement.remove();
+  }
+
+  private clearFocusLabel() {
+    if (!this.focusLabel) return;
+    this.scene.remove(this.focusLabel);
+    if (this.focusLabel.element.parentElement) {
+      this.focusLabel.element.parentElement.removeChild(this.focusLabel.element);
+    }
+    this.focusLabel = null;
+  }
+
+  /**
+   * 코스 stop 좌표 1개 + 주변 N개 강조 모드.
+   * target 빌딩: 빨강 + emissive glow + 윤곽선 + 위쪽 라벨.
+   * neighbors: 파란색 단일 merged mesh.
+   * 기존 빌딩 모두 clear 한 뒤 11개(또는 그 이하)만 렌더.
+   */
+  async loadFocusedBuildings(
+    target: BuildingData | null,
+    neighbors: BuildingData[],
+    center: { lat: number; lon: number },
+    targetLabel?: string,
+  ): Promise<void> {
+    this.clearBuildings();
+    this.clearFocusLabel();
+    this.setCenter(center.lat, center.lon);
+
+    const generation = ++this.buildGeneration;
+
+    // Target — 빨간색 + emissive + outline + label
+    if (target) {
+      const targetGeo = this.buildExtrudeForBuilding(target);
+      if (targetGeo) {
+        const targetMat = new THREE.MeshPhongMaterial({
+          color: 0xDC2626,
+          emissive: 0xDC2626,
+          emissiveIntensity: 0.4,
+          transparent: true,
+          opacity: 0.95,
+          shininess: 50,
+        });
+        const targetMesh = new THREE.Mesh(targetGeo, targetMat);
+        targetMesh.castShadow = true;
+        targetMesh.receiveShadow = true;
+        targetMesh.scale.y = 0.01;
+        targetMesh.userData.targetScaleY = 1;
+        this.scene.add(targetMesh);
+        this.buildings.push(targetMesh);
+
+        // 윤곽선 — EdgesGeometry. target mesh 의 자식으로 붙여 같이 변환.
+        const edges = new THREE.EdgesGeometry(targetGeo, 20);
+        const edgeMat = new THREE.LineBasicMaterial({
+          color: 0xFEE2E2,
+          transparent: true,
+          opacity: 0.9,
+        });
+        const edgeLines = new THREE.LineSegments(edges, edgeMat);
+        targetMesh.add(edgeLines);
+
+        // 라벨 — target 위쪽 (높이 + 30m 정도).
+        if (targetLabel) {
+          const labelDiv = document.createElement('div');
+          labelDiv.textContent = targetLabel;
+          labelDiv.style.cssText = `
+            background: rgba(220, 38, 38, 0.92);
+            color: #fff;
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 10px;
+            border-radius: 9999px;
+            white-space: nowrap;
+            box-shadow: 0 4px 14px rgba(220,38,38,0.4);
+            transform: translate(-50%, -100%);
+            font-family: 'Pretendard Variable', system-ui, sans-serif;
+            letter-spacing: -0.01em;
+          `;
+          const labelObj = new CSS2DObject(labelDiv);
+          // 빌딩 footprint 중심 위치 계산
+          let cx = 0;
+          let cz = 0;
+          for (const [lat, lon] of target.coords) {
+            const local = this.latLonToLocal(lat, lon);
+            cx += local.x;
+            cz += local.z;
+          }
+          cx /= target.coords.length;
+          cz /= target.coords.length;
+          labelObj.position.set(cx, target.height + 30, cz);
+          this.scene.add(labelObj);
+          this.focusLabel = labelObj;
+        }
+      }
+    }
+
+    // Neighbors — 단일 merged blue mesh
+    const neighborGeos: THREE.BufferGeometry[] = [];
+    for (const b of neighbors) {
+      if (generation !== this.buildGeneration) return;
+      const geo = this.buildExtrudeForBuilding(b);
+      if (geo) neighborGeos.push(geo);
+    }
+
+    if (generation !== this.buildGeneration) {
+      for (const g of neighborGeos) g.dispose();
+      return;
+    }
+
+    if (neighborGeos.length > 0) {
+      const merged = mergeGeometries(neighborGeos, false);
+      for (const g of neighborGeos) g.dispose();
+      if (merged) {
+        const mesh = new THREE.Mesh(
+          merged,
+          new THREE.MeshPhongMaterial({
+            color: 0x3B82F6,
+            transparent: true,
+            opacity: 0.82,
+            shininess: 25,
+          }),
+        );
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        mesh.scale.y = 0.01;
+        mesh.userData.targetScaleY = 1;
+        this.scene.add(mesh);
+        this.buildings.push(mesh);
+      }
+    }
+
+    this.animateBuildings();
+  }
+
+  /** 페이드아웃 → loadFocusedBuildings. transitionBuildings 와 동일 패턴. */
+  transitionFocusedBuildings(
+    target: BuildingData | null,
+    neighbors: BuildingData[],
+    center: { lat: number; lon: number },
+    targetLabel?: string,
+  ) {
+    if (this.buildings.length === 0) {
+      this.loadFocusedBuildings(target, neighbors, center, targetLabel);
+      return;
+    }
+    const oldMeshes = [...this.buildings];
+    const fadeOutDuration = 300;
+    const fadeStart = performance.now();
+
+    const fadeOut = (now: number) => {
+      const t = Math.min((now - fadeStart) / fadeOutDuration, 1);
+      for (const m of oldMeshes) {
+        const mat = m.material as THREE.MeshPhongMaterial;
+        mat.opacity = (mat.opacity ?? 0.92) * (1 - t);
+        m.scale.y = m.userData.targetScaleY * (1 - t * 0.3);
+      }
+      this.requestRender();
+      if (t < 1) {
+        requestAnimationFrame(fadeOut);
+      } else {
+        for (const m of oldMeshes) {
+          m.traverse((c) => {
+            if ((c as THREE.Mesh).geometry) (c as THREE.Mesh).geometry.dispose();
+            const mat = (c as THREE.Mesh).material;
+            if (mat) {
+              if (Array.isArray(mat)) mat.forEach((mm) => mm.dispose());
+              else (mat as THREE.Material).dispose();
+            }
+          });
+          this.scene.remove(m);
+        }
+        this.buildings = [];
+        this.loadFocusedBuildings(target, neighbors, center, targetLabel);
+      }
+    };
+    requestAnimationFrame(fadeOut);
+  }
+
+  // 단일 빌딩 ExtrudeGeometry 빌드. 좌표가 적거나 잘못된 경우 null.
+  private buildExtrudeForBuilding(b: BuildingData): THREE.BufferGeometry | null {
+    try {
+      const pts = b.coords.map(([lat, lon]) => this.latLonToLocal(lat, lon));
+      if (pts.length < 3) return null;
+      const shape = new THREE.Shape();
+      shape.moveTo(pts[0].x, -pts[0].z);
+      for (let i = 1; i < pts.length; i++) shape.lineTo(pts[i].x, -pts[i].z);
+      shape.closePath();
+      const geo = new THREE.ExtrudeGeometry(shape, { depth: b.height, bevelEnabled: false });
+      geo.rotateX(-Math.PI / 2);
+      return geo;
+    } catch {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
## 작업 내용
3D 모드에서 코스 stop 좌표가 어느 건물인지 한 눈에 안 보이던 문제 개선.

### 동작 변경
- **이전**: stop 좌표 반경 500m 안의 빌딩 수백~수천을 높이별 5색으로 깔음
- **이후**: target 1개 (빨강) + 가까운 N개 (파랑, 5/10/15 토글) 만 렌더

### 신규 파일
- `src/lib/focus-buildings.ts` — `pickFocusBuildings(buildings, coord, n)`
  - target: point-in-polygon 매치, 실패 시 centroid 최단거리 fallback
  - neighbors: 남은 빌딩 중 거리 sort top N

### 변경 파일
- `src/lib/three-scene.ts`:
  - **CSS2DRenderer 추가** — DOM 라벨 오버레이. canvas 부모에 absolute. 렌더 루프에 동기화
  - `loadFocusedBuildings(target, neighbors, center, label)`:
    - target: 빨강 + emissive glow + EdgesGeometry 윤곽선 + CSS2DObject 라벨(place 이름 pill)
    - neighbors: 파랑 merged 단일 mesh
  - `transitionFocusedBuildings`: 페이드아웃 → focused 로드 (기존 transition 패턴)
  - `buildGeneration` cancel 토큰 호환

- `src/components/map/ThreeMap.tsx`:
  - navigation effect 에서 pickFocusBuildings → transitionFocusedBuildings
  - `neighborCount` prop 추가 (default 10), `stop.placeName` 을 targetLabel 로 전달

- `src/components/map/MapPanel.tsx`:
  - `neighborCount` state (5/10/15)
  - 3D + navigation 시 우상단에 세그먼티드 토글 노출

### 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)