### PR TITLE
feat: 지도 마커 혼잡도 점 + 실제 BE 데이터 heatmap

### DIFF
--- a/src/components/map/GoogleMap.tsx
+++ b/src/components/map/GoogleMap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import type { Place } from '@/types';
-import { CATEGORY_CONFIG } from '@/lib/utils';
+import { CATEGORY_CONFIG, CONGESTION_CONFIG } from '@/lib/utils';
 import { loadMaps, loadMarker } from '@/lib/google-maps-loader';
 import { useMapStore } from '@/stores/mapStore';
 
@@ -73,6 +73,23 @@ function buildMarkerContent(
     </div>`;
   }
 
+  // 혼잡도 인디케이터 — 마커 좌하단에 작은 점. 상단 우측 뱃지(코스 번호/북마크 별)와 충돌 안 함.
+  // BE PlaceBlock.congestion 이 있을 때만 표시. 카드의 한산/보통/혼잡 pill과 같은 컬러 토큰 사용.
+  let congestionDot = '';
+  if (place.congestion) {
+    const cong = CONGESTION_CONFIG[place.congestion.level];
+    congestionDot = `<div data-congestion style="
+      position: absolute;
+      bottom: -4px; left: -4px;
+      width: 14px; height: 14px;
+      background: ${cong.color};
+      border-radius: 50%;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.25);
+      border: 2px solid white;
+      pointer-events: none;
+    " title="혼잡도: ${cong.label}"></div>`;
+  }
+
   // In itinerary mode the side panel owns the place names — hide the map
   // label to avoid duplicating information.
   const labelHtml = itineraryMode
@@ -122,6 +139,7 @@ function buildMarkerContent(
         filter: url(#markerInkBleed);
       ">${cat.label[0]}</div>
       ${badge}
+      ${congestionDot}
     </div>
     ${labelHtml}
   `;

--- a/src/components/map/MapPanel.tsx
+++ b/src/components/map/MapPanel.tsx
@@ -3,8 +3,6 @@ import { MapPin, Box, Map, Flame, Route } from 'lucide-react';
 import { useMapStore } from '@/stores/mapStore';
 import { useBookmarkStore } from '@/stores/bookmarkStore';
 import { CONGESTION_CONFIG } from '@/lib/utils';
-import placesData from '@/mocks/places.json';
-import type { Place } from '@/types';
 import PlaceOverlayCarousel from './PlaceOverlayCarousel';
 import EmptyState from '@/components/ui/EmptyState';
 import LottiePlayer from '@/components/ui/LottiePlayer';
@@ -79,22 +77,20 @@ export default function MapPanel() {
 
   const hasContent = displayMarkers.length > 0 || is3D;
 
-  // Congestion overlay — mock places.json 기반 demo 시각화.
-  // prod에선 노출 차단 (BE 혼잡도는 PlaceCard 뱃지로 표시).
+  // Congestion overlay — 현재 화면에 표시된 마커들 중 BE congestion 정보가 있는 것만 사용.
+  // BE PlaceBlock.congestion (area_proxy 단위 혼잡도)을 실제 데이터 소스로 활용.
   const congestionPoints = useMemo(
-    () => {
-      if (!import.meta.env.DEV) return [];
-      return (placesData as Place[])
-        .filter((p): p is Place & { congestion: NonNullable<Place['congestion']> } => !!p.congestion)
+    () =>
+      displayMarkers
+        .filter((p) => !!p.congestion)
         .map((p) => {
-          const level = p.congestion.level;
+          const level = p.congestion!.level;
           const cfg = CONGESTION_CONFIG[level];
-          // low 150m / medium 250m / high 400m
+          // low 150m / medium 250m / high 400m — 레벨이 높을수록 영향 반경도 넓음.
           const radiusMeters = level === 'high' ? 400 : level === 'medium' ? 250 : 150;
           return { lat: p.lat, lng: p.lng, color: cfg.color, radiusMeters };
-        });
-    },
-    [],
+        }),
+    [displayMarkers],
   );
 
   // Auto-off heatmap when switching to 3D (visualization is 2D-only here)


### PR DESCRIPTION
## 작업 내용
**옵션 A 채택** — 지도 마커 혼잡도 인디케이터 + 진짜 BE 데이터 heatmap.

### 변경
1. **GoogleMap 마커에 혼잡도 점 표시** (`src/components/map/GoogleMap.tsx`)
   - `place.congestion` 이 있는 마커의 좌하단에 14px 작은 원형 점 추가
   - `CONGESTION_CONFIG` 컬러 토큰 (low: green / medium: amber / high: red) 사용
   - 상단 우측의 코스 번호/북마크 별 뱃지와 위치 충돌 없음
   - 카드 뱃지(`PlaceCard`, `PlaceOverlayItem`)와 시각적 일관성 확보
   - `title` 속성으로 호버 툴팁 — 접근성 보조

2. **heatmap 데이터 소스 BE 화** (`src/components/map/MapPanel.tsx`)
   - `congestionPoints` 를 `displayMarkers` 중 `place.congestion` 이 있는 항목에서 산출
   - 기존 `import.meta.env.DEV ? mocks/places.json : []` 분기 제거
   - 더는 쓰지 않는 `placesData` / `Place` 타입 import 정리
   - prod 에서도 실제 BE PlaceBlock.congestion 데이터로 heatmap 동작

## 변경 파일
- `src/components/map/GoogleMap.tsx`  — 마커 빌더에 congestion dot 주입 + `CONGESTION_CONFIG` import
- `src/components/map/MapPanel.tsx`   — `congestionPoints` 산출 로직을 BE 데이터 기반으로 교체

## 검증
- `pnpm exec tsc --noEmit` → 0 errors
- `pnpm test --run` → 13/13 pass (utils 7 + chatStore 6)
- 기존 동작 유지: 마커 도장 애니메이션, 선택 스타일, 코스 폴리라인, 북마크 별, 3D/2D 토글, heatmap 토글/범례, 카드 뱃지 모두 영향 없음
- 디자인 토큰 준수: `CONGESTION_CONFIG.color` 재사용 (카드/지도 통일)

## 체크리스트
- [x] AGENTS.md 스키마 준수 (`PlaceBlockData.congestion` 그대로 소비)
- [x] 빈 상태 처리 (congestion 없는 마커는 점 미표시)
- [x] 모바일 반응형 (점은 마커 위치 기반이라 추가 레이아웃 변경 없음)
- [x] 디자인 토큰 (`CONGESTION_CONFIG`) 준수