### PR TITLE
fix: 채팅 미니맵 마커가 전부 같은 카테고리로 보이던 문제

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -139,7 +139,7 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
             {message.blocks && message.blocks.length > 0 && (
               <div data-reveal className="space-y-2">
                 {message.blocks.map((block, i) => (
-                  <BlockRenderer key={`${block.type}-${i}`} block={block} />
+                  <BlockRenderer key={`${block.type}-${i}`} block={block} places={message.places} />
                 ))}
               </div>
             )}

--- a/src/components/chat/blocks/MapBlock.tsx
+++ b/src/components/chat/blocks/MapBlock.tsx
@@ -5,11 +5,18 @@ import GoogleMap from '@/components/map/GoogleMap';
 
 interface MapBlockProps {
   markers: MarkerItem[];
+  // 같은 메시지의 places 블록 결과 — place_id 매칭으로 진짜 카테고리/이미지 복원 용.
+  places?: Place[];
 }
 
-// SSE map_markers 블록 → 인라인 미니맵.
-// MarkerItem({ place_id, lat, lng, label })을 GoogleMap이 요구하는 Place 스텁으로 변환.
-function markerToPlace(m: MarkerItem): Place {
+// BE MarkerItem 은 { place_id, lat, lng, label } 만 들고 카테고리/이미지 없음.
+// 같은 메시지 places 블록에서 place_id 매칭되면 그 Place 사용 — 우측 패널과 시각 일치.
+// 매칭 안 되면 stub (모든 핀이 tourism 으로 보이던 이전 동작 — fallback).
+function markerToPlace(m: MarkerItem, placesById: Map<string, Place>): Place {
+  const matched = placesById.get(m.place_id);
+  if (matched) {
+    return { ...matched, lat: m.lat, lng: m.lng, name: m.label ?? matched.name };
+  }
   return {
     id: m.place_id,
     name: m.label ?? m.place_id,
@@ -23,18 +30,26 @@ function markerToPlace(m: MarkerItem): Place {
   };
 }
 
-export default function MapBlock({ markers }: MapBlockProps) {
-  const places = useMemo(() => markers.map(markerToPlace), [markers]);
+export default function MapBlock({ markers, places }: MapBlockProps) {
+  const placesById = useMemo(() => {
+    const map = new Map<string, Place>();
+    for (const p of places ?? []) map.set(p.id, p);
+    return map;
+  }, [places]);
+  const resolvedPlaces = useMemo(
+    () => markers.map((m) => markerToPlace(m, placesById)),
+    [markers, placesById],
+  );
 
-  if (places.length === 0) return null;
+  if (resolvedPlaces.length === 0) return null;
 
   return (
     <div className="rounded-xl border border-border overflow-hidden bg-bg-surface">
       <div className="h-[260px] w-full">
-        <GoogleMap markers={places} selectedPlace={null} onSelectPlace={() => {}} />
+        <GoogleMap markers={resolvedPlaces} selectedPlace={null} onSelectPlace={() => {}} />
       </div>
       <div className="px-3 py-2 text-[11px] text-text-muted border-t border-border">
-        지도에 표시된 장소 {places.length}곳
+        지도에 표시된 장소 {resolvedPlaces.length}곳
       </div>
     </div>
   );

--- a/src/components/chat/blocks/index.tsx
+++ b/src/components/chat/blocks/index.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactElement } from 'react';
 import type { Block } from '@/types/api';
+import type { Place } from '@/types';
 import ChartBlock from './ChartBlock';
 import EventsBlock from './EventsBlock';
 import ReferencesBlock from './ReferencesBlock';
@@ -22,7 +23,7 @@ export {
   CalendarBlock,
 };
 
-export function BlockRenderer({ block }: { block: Block }): ReactElement | null {
+export function BlockRenderer({ block, places }: { block: Block; places?: Place[] }): ReactElement | null {
   switch (block.type) {
     case 'chart':
       return <ChartBlock data={block} />;
@@ -35,7 +36,8 @@ export function BlockRenderer({ block }: { block: Block }): ReactElement | null 
     case 'disambiguation':
       return <DisambiguationBlock data={block} />;
     case 'map_markers':
-      return <MapBlock markers={block.markers} />;
+      // places 가 있으면 place_id 매칭으로 진짜 카테고리/이미지 복원 (BE MarkerItem 은 카테고리 미포함).
+      return <MapBlock markers={block.markers} places={places} />;
     case 'map_route':
       return <MapRouteBlock data={block} />;
     case 'calendar':


### PR DESCRIPTION
## 증상
채팅 인라인 미니맵의 모든 도장이 파란색(tourism) 으로 동일 → 우측 지도 패널은 카테고리 색 다양 → 같은 장소가 다른 색으로 표시되어 혼란.

## 원인
BE `MarkerItem = { place_id, lat, lng, label }` — 카테고리 없음.
`MapBlock.markerToPlace` 가 `category: 'tourism'` 을 하드코딩.

## 수정
- `BlockRenderer` 에 `places?: Place[]` prop 추가
- `MessageBubble` 이 `message.places` 를 `BlockRenderer` 로 전달
- `MapBlock` 이 `place_id` 매칭으로 진짜 Place 복원 (category/image/이름 모두) → 매칭 안 되면 stub fallback (이전 동작 보존)

채팅 미니맵 ↔ 우측 패널 지도 시각 일치.

## 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)