### PR TITLE
fix(upload): Vercel 4.5MB body limit 우회 — BE 직접 호출

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -289,11 +289,20 @@ export const calendarApi = {
 };
 
 // 이미지 업로드 — GCS 임시 저장 후 1시간짜리 signed URL 반환.
+//
+// Vercel proxy/rewrite 는 request body 4.5MB 제한이 있어 prod 에서 큰 사진이 413.
+// 해결: prod 빌드에서 Vercel 우회 — BE 도메인 직접 호출. BE 에 vercel.app CORS 허용 됨.
+// dev 에선 vite proxy 그대로 사용 (same-origin).
+// 향후 BE IP 변경 시 VITE_UPLOAD_BASE 환경변수로 덮어쓰기 가능.
+const UPLOAD_BASE: string =
+  (import.meta.env.VITE_UPLOAD_BASE as string | undefined) ??
+  (import.meta.env.DEV ? '' : 'https://34.50.44.75.nip.io');
+
 export const uploadApi = {
   image: (file: File) => {
     const fd = new FormData();
     fd.append('file', file);
-    return request<ImageUploadResponse>('/api/v1/upload/image', {
+    return request<ImageUploadResponse>(`${UPLOAD_BASE}/api/v1/upload/image`, {
       method: 'POST',
       body: fd,
     });


### PR DESCRIPTION
## 증상
prod (Vercel) 에서 큰 사진 (4.5MB 초과) 업로드 시 413.

## 원인
Vercel proxy/rewrite 의 request body 제한 (~4.5MB). 우리는 BE 가 10MB 까지 허용하는데 Vercel 단에서 먼저 잘림.

## 수정
BE 팀 안내대로 **upload 만 Vercel 우회 → BE 직접 호출**:
- `dev` (vite proxy): 변경 없음, same-origin
- `prod` (Vercel): 절대 URL `https://34.50.44.75.nip.io/api/v1/upload/image` 직접 호출
- `VITE_UPLOAD_BASE` env var 로 향후 BE IP 변경 대비 덮어쓰기 가능
- 다른 API 들은 그대로 (json body 라 4.5MB 한참 미만)

BE 측 CORS 가 vercel.app 도메인 허용해 둠 (확인됨).

## 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)