### PR TITLE
perf: Pretendard self-host + vendor manualChunks + Lottie lazy

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,27 +6,19 @@
     <title>Seoul AI Guide</title>
     <meta name="description" content="서울의 모든 경험을 AI 에이전트와 함께" />
 
-    <!-- Preconnect to font origins -->
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <!-- Pretendard 는 self-host (npm 'pretendard') — main.tsx 에서 import.
+         Vercel 정적 자산 immutable 캐시(1년) 적용되어 CDN 7일 TTL 대비 캐시 효율 향상. -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
-    <!-- Non-blocking font loading: swap-in when ready -->
-    <link
-      rel="preload"
-      as="style"
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
+    <!-- 영문/Display 폰트만 Google CDN 유지 (self-host 시 복수 파일 + 다국어 subset 관리 부담) -->
     <link
       rel="preload"
       as="style"
       href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Archivo:wght@400;500;600;700;900&family=Inter:wght@400;500;600;700&display=swap"
       onload="this.onload=null;this.rel='stylesheet'"
     />
-    <!-- Fallback for JS-disabled browsers -->
     <noscript>
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
       <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Archivo:wght@400;500;600;700;900&family=Inter:wght@400;500;600;700&display=swap" />
     </noscript>
   </head>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gsap": "^3.15.0",
     "lottie-react": "^2.4.1",
     "lucide-react": "^0.577.0",
+    "pretendard": "^1.3.9",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-router-dom": "^7.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
+      pretendard:
+        specifier: ^1.3.9
+        version: 1.3.9
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1634,6 +1637,9 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pretendard@1.3.9:
+    resolution: {integrity: sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -3474,6 +3480,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  pretendard@1.3.9: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/src/components/ui/LottiePlayer.tsx
+++ b/src/components/ui/LottiePlayer.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from 'react';
-import Lottie from 'lottie-react';
+import { useEffect, useState, type ComponentType } from 'react';
 
 interface LottiePlayerProps {
   /** Path under /public (e.g. '/animations/loading.json') or full URL */
   src: string;
-  /** Fallback node shown while fetching or if the file is missing */
+  /** Fallback node shown while fetching JSON or loading the Lottie runtime */
   fallback?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
@@ -14,7 +13,22 @@ interface LottiePlayerProps {
 }
 
 type Data = Record<string, unknown>;
-const cache = new Map<string, Data>();
+type LottieComp = ComponentType<{
+  animationData: Data;
+  loop?: boolean;
+  autoplay?: boolean;
+}>;
+
+const dataCache = new Map<string, Data>();
+// lottie-react 모듈은 한 번 import 하면 캐시 — 반복 LottiePlayer 가 다시 import 안 함.
+let lottieModulePromise: Promise<LottieComp> | null = null;
+
+function loadLottie(): Promise<LottieComp> {
+  if (!lottieModulePromise) {
+    lottieModulePromise = import('lottie-react').then((m) => m.default as LottieComp);
+  }
+  return lottieModulePromise;
+}
 
 export default function LottiePlayer({
   src,
@@ -25,9 +39,11 @@ export default function LottiePlayer({
   autoplay = true,
   ariaLabel,
 }: LottiePlayerProps) {
-  const [data, setData] = useState<Data | null>(() => cache.get(src) ?? null);
+  const [data, setData] = useState<Data | null>(() => dataCache.get(src) ?? null);
+  const [Lottie, setLottie] = useState<LottieComp | null>(null);
   const [failed, setFailed] = useState(false);
 
+  // JSON fetch
   useEffect(() => {
     if (data || failed) return;
     let cancelled = false;
@@ -35,14 +51,24 @@ export default function LottiePlayer({
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
       .then((json: Data) => {
         if (cancelled) return;
-        cache.set(src, json);
+        dataCache.set(src, json);
         setData(json);
       })
       .catch(() => { if (!cancelled) setFailed(true); });
     return () => { cancelled = true; };
   }, [src, data, failed]);
 
-  if (failed || !data) {
+  // Lottie 모듈 lazy import — JSON 받은 뒤 한 번만.
+  useEffect(() => {
+    if (!data || Lottie) return;
+    let cancelled = false;
+    loadLottie()
+      .then((Comp) => { if (!cancelled) setLottie(() => Comp); })
+      .catch(() => { if (!cancelled) setFailed(true); });
+    return () => { cancelled = true; };
+  }, [data, Lottie]);
+
+  if (failed || !data || !Lottie) {
     return <>{fallback}</>;
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { createRoot } from 'react-dom/client';
 import { StrictMode, useEffect, lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import App from './App';
+// Pretendard self-host — Vite 가 woff2 subset 들을 dist/assets/ 로 복사 + content-hash
+// → Vercel immutable 캐시 적용. 브라우저는 unicode-range 매칭되는 subset 만 fetch.
+import 'pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css';
 import './globals.css';
 import { useAuthStore } from '@/stores/authStore';
 import RequireAuth from '@/components/auth/RequireAuth';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,22 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    // 메인 번들에서 큰 vendor 라이브러리들을 별도 chunk 로 분리.
+    // 효과: (1) 앱 코드만 변경 시 vendor chunk 는 캐시 재사용 → 재방문 빠름
+    //       (2) 메인 index.js 크기 감소 → 초기 파싱/평가 시간 단축
+    // ※ Three.js 는 이미 React.lazy 로 동적 import → 자동으로 별도 chunk.
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-gsap': ['gsap', '@gsap/react'],
+          'vendor-lottie': ['lottie-react'],
+          'vendor-google-maps': ['@googlemaps/js-api-loader'],
+        },
+      },
+    },
+  },
   optimizeDeps: {
     // Pre-bundle everything commonly imported. Vite serves each module via
     // native ESM in dev — libs that ship hundreds of tiny files (three,


### PR DESCRIPTION
## Lighthouse 지표 대응
### 캐시 수명 244KiB 절감
- Pretendard 폰트 self-host (npm 'pretendard') → Vite 가 woff2 subset 들을 dist/assets/ 로 content-hash 복사 → Vercel immutable 캐시(1년)
- 이전 jsdelivr CDN 7일 TTL → 영구 캐시로 개선

### 사용되지 않는 JS / 메인 번들 분리
- Vite manualChunks 로 vendor 4종 분할 (react/gsap/lottie/google-maps)
- LottiePlayer 가 'lottie-react' 를 동적 import → 초기 로딩 entry 에서 제외

### 초기 로딩 bundle (gzip)
- index.js 118KiB + vendor-react 17KiB + vendor-gsap 28KiB ≈ **163KiB**
- vendor-lottie / ThreeMap / buildings-jongno / overpass 모두 lazy

## 변경 파일
- index.html — Pretendard CDN preload/noscript 제거
- src/main.tsx — pretendard dynamic-subset CSS import
- src/components/ui/LottiePlayer.tsx — lottie-react 동적 import + 전역 모듈 캐시
- vite.config.ts — build.rollupOptions.output.manualChunks
- package.json — pretendard 의존성 추가

## 검증
- typecheck 0 errors
- 13/13 tests pass
- pnpm build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)