### PR TITLE
docs(portfolio): Lighthouse 성능 최적화 작업 추가

### DIFF
--- a/docs/portfolio-2026-05.md
+++ b/docs/portfolio-2026-05.md
@@ -433,24 +433,105 @@ PlaceCard 의 한산/보통/혼잡 pill 은 prod 동작 중이지만, **지도 �
 
 ---
 
-## 11. 정량 종합
+## 11. Lighthouse 성능 최적화 — 폰트 캐시 + 번들 분할
+
+### Situation
+배포된 prod 사이트에서 Lighthouse 측정 결과:
+- **LCP 9,020ms** (목표 < 2,500ms) — 메인 요소(첫 채팅 텍스트) 렌더 지연
+- 효율적인 캐시 수명 — 예상 절감 **244KiB** (Pretendard 폰트 jsdelivr CDN 7일 TTL)
+- 사용되지 않는 JS — **133.5KiB** (메인 index.js)
+- JS 실행 시간 — **2.96s** (main thread 부담)
+
+### Task
+- 폰트 캐시 효율 향상 (재방문 시 폰트 0 bytes 재요청)
+- 초기 로딩 메인 번들에서 lazy 가능한 라이브러리 분리
+- vendor chunk 분리로 앱 코드 변경 시에도 vendor 캐시 재사용
+
+### Action
+
+#### 검토한 옵션
+| 옵션 | 장점 | 단점 |
+|---|---|---|
+| A. CDN 그대로 + Cache-Control 헤더 조정 | 변경 0 | CDN(jsdelivr) 정책이라 우리가 제어 못 함 |
+| B. Pretendard self-host (npm) | Vercel immutable 1년 캐시, 우리 제어 | 의존성 1개 추가, dist 폴더 fonts 3MB |
+| C. Service Worker 로 폰트 캐시 | 더 정교한 정책 | 라이프사이클 관리 복잡, MSW 와 충돌 잠재 |
+
+#### 선택: B (self-host)
+- Vite 가 woff2 dynamic-subset 파일들을 dist/assets/ 로 content-hash 복사 → 콘텐츠 변경 없으면 동일 URL → Vercel 자산 자동 immutable cache
+- 7일 TTL → 1년 immutable (사용자 체감 첫 로딩 이후 폰트 0 cost)
+
+#### 구현 (PR #92)
+1. **Pretendard self-host**:
+   - `npm i pretendard` → main.tsx 에서 `import 'pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css'`
+   - index.html 의 jsdelivr `<link preload>` + `<noscript>` fallback 제거
+   - Vite 가 unicode-range 매칭 woff2 subset 들을 dist/ 로 hash 복사
+
+2. **Vite manualChunks** — vendor 4종 분리:
+   ```ts
+   manualChunks: {
+     'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+     'vendor-gsap': ['gsap', '@gsap/react'],
+     'vendor-lottie': ['lottie-react'],
+     'vendor-google-maps': ['@googlemaps/js-api-loader'],
+   }
+   ```
+   - 앱 코드 변경 시 vendor chunk 캐시 hit
+   - main bundle 에서 React/GSAP/Lottie/Maps 분리
+
+3. **Lottie 진짜 lazy** (LottiePlayer 내부):
+   - `import Lottie from 'lottie-react'` → `const Lottie = lazy(() => import('lottie-react'))` 대신 useEffect 안에서 `import()` + 전역 모듈 캐시
+   - JSON fetch 완료 후 한 번만 module load. 미로드 시 fallback (단순 spinner) 노출
+   - vendor-lottie chunk 가 초기 entry 참조 안 됨 → 첫 로딩에서 fetch 안 됨
+
+### Result
+
+| 지표 | 이전 | 이후 |
+|---|---|---|
+| 초기 로딩 bundle (gzip) | main 217KiB (lottie 포함) | index 118 + vendor-react 17 + vendor-gsap 28 ≈ **163KiB** |
+| Pretendard 캐시 TTL | 7일 (CDN) | 1년 (immutable) |
+| 재방문 시 폰트 fetch | 244KiB (Lighthouse 측정) | 0 bytes |
+| Lottie 초기 로딩 비용 | 82KiB gzip (vendor 포함) | 0 (lazy chunk, EmptyState 표시 시점만) |
+| 신규 chunks | 0 | 4 (vendor-react/gsap/lottie/google-maps) |
+| Three.js / Overpass / buildings-jongno | lazy 일부 | 그대로 lazy (변경 없음) |
+
+#### lazy chunks 현황 (gzip)
+| chunk | 크기 | 로드 시점 |
+|---|---|---|
+| vendor-lottie | 82KiB | EmptyState/loading 표시 시 |
+| ThreeMap | 150KiB | 3D 토글 시 |
+| buildings-jongno | 111KiB | 종로 3D 진입 시 |
+| overpass | 21KiB | 3D + 코스 진행 시 |
+| MapPanel | 8KiB | 지도 탭 진입 시 |
+| BookmarkPanel | 4KiB | 북마크 탭 진입 시 |
+| CalendarPanel | 2KiB | 일정 탭 진입 시 |
+
+### Trade-off / 미해결
+- **LCP 9020ms 잔여**: bundle 크기 줄여도 LCP 첫 화면 렌더 시간이 9초인 건 첫 메시지/welcome 렌더 자체가 느리다는 신호 (AgentOrb / SSE 첫 응답 wait 등). 추가 분석 필요 — 후속 사이클
+- **buildings-jongno 1.18MB raw**: lazy 라 초기 로딩은 안 받지만 종로 3D 진입 시 큰 부담. binary format / brotli pre-compress 가능성. 후속
+- **사용 되지 않는 JS 133KiB 일부 잔여**: chrome-extension 측 113KiB 는 사용자 환경 외부 (광고 차단 등) — 우리가 못 줄임. vercel.app 측 133KiB 는 react/gsap/store/components glue 라 추가 분할 ROI 낮음
+
+---
+
+## 12. 정량 종합
 
 | 지표 | 값 |
 |---|---|
-| 머지된 PR | 26건 |
+| 머지된 PR | 28건 (#64 ~ #92) |
 | 평균 PR 사이클 | 작성 → 검증 → PR → 머지 ~20분 |
-| 신규 라이브러리 도입 | 2개 (gsap, @gsap/react) |
-| 신규 코드 파일 | 12개 (focus-buildings, seoul-districts, buildings-cache, tile-cache, prefetch-3d, gsap-setup, flip-to-marker, stop-category, MapBlock, Google3DMap 설계 등) |
+| 신규 라이브러리 도입 | 3개 (gsap, @gsap/react, pretendard) |
+| 신규 코드 파일 | 13개 (focus-buildings, seoul-districts, buildings-cache, tile-cache, prefetch-3d, gsap-setup, flip-to-marker, stop-category, MapBlock, Google3DMap 설계, vite manualChunks 등) |
 | 삭제/대체된 코드 | ~250줄 (MapMarkersBlock, INTERESTS 등) |
 | 삭제된 mock 의존 | 4 곳 (BookingPanel, bookmarkStore 시드, MapPanel congestionPoints, ItineraryCard 카테고리 결정) |
 | 차단된 prod 누출 | 4 경로 (MSW SW + 3개 mock JSON) |
 | 신규 BE API 연동 | 7개 엔드포인트 (place-bookmarks 3, calendar 2, upload 1, 기타) |
 | 테스트 | 13/13 유지 (회귀 0) |
-| 번들 변화 | gsap ~53KB 추가 / mock 의존 일부 제거 / Three.js 그대로 |
+| 초기 로딩 bundle (gzip) | 217KiB → **163KiB** (-25%) |
+| 폰트 캐시 효율 | 7일 → **1년** immutable |
+| lazy chunk 수 | 7 (vendor 3 + 페이지/패널 4) |
 
 ---
 
-## 12. 회고 — 다음에 했더라면
+## 13. 회고 — 다음에 했더라면
 
 1. **3D 재설계** — Three.js 자체 빌딩 시스템 대신 Google Photorealistic 3D Tiles 였으면 ~1500줄 코드 절약. 그러나 빌링 권한 협의가 필요해서 설계 문서로 남김. 다음 사이클에서 진행
 2. **이미지 업로드** — BE 환경변수(GCS bucket) 설정이 사용자 환경에 의존 → FE 가 검증 가능한 영역 밖이라 prod 검증이 느림. 다음엔 PR 머지 전 BE 팀 환경 사전 확인 protocol 정착

--- a/docs/portfolio-tech-highlights.md
+++ b/docs/portfolio-tech-highlights.md
@@ -377,6 +377,37 @@ Prod 에서 사용자가 "mock 데이터가 자꾸 보임" 호소. 코드 검사
 
 ---
 
+## 14. Vite manualChunks + Lazy Lottie + Self-host Pretendard
+
+### 한 문장
+Lighthouse 측정으로 발견한 캐시 효율 244KiB / 메인 번들 215KiB 문제를 **vendor 4종 분할 + 동적 import lottie + 폰트 self-host** 로 초기 로딩 25% 감축 + 폰트 영구 캐시.
+
+### 정량
+| 지표 | 이전 | 이후 |
+|---|---|---|
+| 초기 로딩 bundle (gzip) | 217KiB | **163KiB** (-25%) |
+| Pretendard 캐시 TTL | 7일 (CDN) | **1년 immutable** |
+| 재방문 시 폰트 fetch | 244KiB | **0 bytes** |
+| Lottie 초기 fetch | 82KiB gzip 포함 | 0 (lazy chunk) |
+| Lazy chunks | 4 (pages) | 7 (+ vendor-lottie + ThreeMap + buildings-jongno + overpass) |
+| 신규 vendor chunks | 0 | 4 (react/gsap/lottie/google-maps) |
+
+### 핵심 디테일
+- **Pretendard self-host via npm**: `import 'pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css'` 한 줄. Vite 가 woff2 subset 들을 dist/assets/ 로 content-hash 복사 → 콘텐츠 변경 없으면 동일 URL → Vercel 자동 immutable 캐시. CDN 7일 TTL → 1년 캐시
+- **manualChunks 전략**: 자주 안 바뀌는 라이브러리(`react`, `gsap`, `lottie-react`, `@googlemaps/js-api-loader`)를 별도 vendor chunk 로 분리. **앱 코드 hash 만 바뀌어도 vendor chunk 캐시는 hit** → 배포 후 재방문 시 React 다시 다운로드 X
+- **Lottie 진짜 lazy**: manualChunks 만으론 lottie-react chunk 가 entry 에서 static reference 되면 결국 함께 로드. LottiePlayer 안에서 `import('lottie-react')` 동적 호출 + 전역 module promise 캐시 → entry 가 vendor-lottie 를 참조 안 함 → 초기 fetch 에서 완전 제외
+- **dynamic-subset 활용**: 단일 woff2 (2MB) 대신 unicode-range 별 subset → 브라우저가 실제 사용 문자에 매칭되는 subset 만 fetch (한국어 사이트는 보통 100-200KB 정도만 로드)
+
+### 다른 흔한 방법을 안 쓴 이유
+- **CDN preconnect/preload 유지**: jsdelivr Cache-Control 정책이 7일이라 우리가 변경 못 함. 호스팅 자체를 우리로 옮기는 게 본질
+- **단일 woff2 (static) 사용**: dynamic-subset 가 한국어 한글 jamo 단위 분할 → 사용 안 한 문자 subset 은 fetch 안 됨. 초기 로딩 더 작음
+- **모든 라이브러리 단일 vendor chunk**: 큰 chunk 1개보다 작은 chunk 여러 개가 캐시 hit ratio 더 좋음 (1 lib 만 변경돼도 1 vendor chunk 만 무효화)
+- **Service Worker 로 폰트 캐시**: MSW SW 와 충돌 가능 + 라이프사이클 관리 복잡. Vercel immutable 캐시가 더 단순하고 안전
+
+**파일**: `src/main.tsx` (pretendard import 추가), `vite.config.ts` (manualChunks), `src/components/ui/LottiePlayer.tsx` (lazy import 패턴), `index.html` (CDN preload 제거)
+
+---
+
 ## 종합 매트릭스
 
 | 기술 영역 | 자체 구현 / 깊이 | 정량 임팩트 |
@@ -394,6 +425,7 @@ Prod 에서 사용자가 "mock 데이터가 자꾸 보임" 호소. 코드 검사
 | Service Worker 잔존 진단 | 브라우저 SW 라이프사이클 이해 | 사용자 측 자동 정리 |
 | 단일 결정점 helper | 데이터 일관성 보장 | 3곳 → 1곳 결정 |
 | Git worktree 병렬 | 영역 분리 + 격리 | 충돌 0, 3분 병렬 |
+| Vite manualChunks + Lazy Lottie + 폰트 self-host | bundle 분할 + 캐시 영구화 | 초기 로딩 -25%, 폰트 캐시 7일 → 1년 |
 
 ---
 
@@ -412,3 +444,4 @@ Prod 에서 사용자가 "mock 데이터가 자꾸 보임" 호소. 코드 검사
 - **MSW Service Worker 잔존 디버깅** — prod 사용자가 mock 응답 받는 원인 진단 후 자동 정리 메커니즘 도입
 - **데이터 일관성 단일 결정점 helper** — 3곳 다른 우선순위 → 1 helper 통일
 - **Git worktree 병렬 작업** — 두 PR 동시 진행 영역 분리, 충돌 0
+- **Lighthouse 대응 (vendor 분할 + lazy Lottie + 폰트 self-host)** — 초기 로딩 217KiB → 163KiB, 폰트 캐시 7일 → 1년


### PR DESCRIPTION
PR #92 의 작업을 포트폴리오 2종 문서에 추가.

### portfolio-2026-05.md
- 신규 섹션 11. Lighthouse 성능 최적화 (STAR)
  - 검토 옵션 3가지, 선택 이유, 구현 디테일, 결과 표
  - 미해결 후속 (LCP 9020ms, buildings-jongno 1.18MB, 잔여 unused JS)
- 12. 정량 종합에 신규 지표 추가 (초기 bundle 217→163KiB, 폰트 캐시 1년, lazy chunk 7개)

### portfolio-tech-highlights.md
- 신규 섹션 14. Vite manualChunks + Lazy Lottie + Self-host Pretendard
  - 한 문장 / 정량 / 핵심 디테일 / 다른 방법 안 쓴 이유
- 종합 매트릭스 + 1줄 요약 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)