### PR TITLE
perf: CSS 비차단 로딩 + MessageBubble ScrollTrigger → IntersectionObserver

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useRef } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { Bookmark } from 'lucide-react';
 import { useGSAP } from '@gsap/react';
 import { gsap } from '@/lib/gsap-setup';
@@ -32,32 +32,31 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
     beMessageIdStr != null && s.messageItems.some((m) => m.messageId === beMessageIdStr),
   );
 
-  // 외곽 컨테이너 진입 효과 — ScrollTrigger 로 스크롤 컨테이너 viewport 진입 시 페이드.
-  // 새로 도착한 메시지는 mount 시 이미 화면 안이라 즉시 발화 (animate-message 대체).
-  // 긴 히스토리에서 위로 스크롤 시 옛 메시지도 진입 타이밍에 자연스럽게 등장.
-  useGSAP(() => {
+  // 외곽 컨테이너 진입 효과 — IntersectionObserver (native, off-main-thread layout) 로 변경.
+  // 이전엔 ScrollTrigger 가 메시지 N개 만큼 layout 측정 트리거 → forced reflow.
+  // IO 는 layout 측정 없이 entry 보고. once 후 disconnect.
+  useEffect(() => {
     if (prefersReducedMotion()) return;
     const el = bubbleRef.current;
     if (!el) return;
     const scroller = el.closest<HTMLElement>('[data-chat-scroller]');
     if (!scroller) return;
-    const tween = gsap.from(el, {
-      y: 14,
-      opacity: 0,
-      duration: 0.45,
-      ease: 'power2.out',
-      scrollTrigger: {
-        trigger: el,
-        scroller,
-        start: 'top 95%',
-        once: true,
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            gsap.from(el, { y: 14, opacity: 0, duration: 0.45, ease: 'power2.out' });
+            io.disconnect();
+            break;
+          }
+        }
       },
-    });
-    return () => {
-      tween.scrollTrigger?.kill();
-      tween.kill();
-    };
-  }, { scope: bubbleRef });
+      { root: scroller, rootMargin: '0px 0px -5% 0px' },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
 
   // 어시스턴트 답변의 자식 섹션(text → places → itinerary → blocks → actions)을
   // 작은 간격으로 순차 reveal. 외곽 ScrollTrigger 와 독립적으로 mount 시 동작.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,26 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, type Plugin } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
+// CSS 가 render-blocking 으로 LCP 300-500ms 지연시키는 문제 해소.
+// build 시점에 entry HTML 의 <link rel="stylesheet"> 를 preload + onload swap 으로 변환.
+// JS-disabled 환경 대비 <noscript> fallback 함께 삽입.
+function asyncCssPlugin(): Plugin {
+  return {
+    name: 'async-css',
+    apply: 'build',
+    transformIndexHtml(html) {
+      return html.replace(
+        /<link rel="stylesheet"(?:\s+crossorigin)?\s+href="([^"]+)">/g,
+        (_m, href: string) =>
+          `<link rel="preload" as="style" href="${href}" onload="this.onload=null;this.rel='stylesheet'"><noscript><link rel="stylesheet" href="${href}"></noscript>`,
+      );
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), asyncCssPlugin()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
이전 Lighthouse 측정 (LCP 4500ms, TBT 120ms) 에서 남은 두 가지 ROI 처리.

## 1. CSS render-blocking 해소
**증상**: entry CSS 22.7KiB / 450ms 가 critical path 차단 → LCP 300ms 지연

**구현**: Vite plugin (인라인) — `transformIndexHtml` 훅에서 `<link rel="stylesheet" href="*.css">` → `<link rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'">` + `<noscript>` fallback 변환

빌드 결과 확인:
\`\`\`
<link rel="preload" as="style" href="/assets/index-DcL8W7rJ.css" onload="this.onload=null;this.rel='stylesheet'">
<noscript><link rel="stylesheet" href="/assets/index-DcL8W7rJ.css"></noscript>
\`\`\`

## 2. MessageBubble ScrollTrigger → IntersectionObserver
**증상**: Lighthouse "강제 실행된 리플로우" — vendor-gsap 34ms / index 35ms

**원인**: ScrollTrigger 가 메시지 N개 만큼 layout 측정 트리거 → forced reflow

**구현**: 외곽 진입 효과를 native IntersectionObserver 로 교체
- off-main-thread layout 측정
- once: true 효과는 disconnect 로 구현
- 내부 [data-reveal] stagger 는 useGSAP 유지 (mount 시 1회만)

## 예상 임팩트
- LCP -300ms (CSS critical path 해소)
- TBT -35ms (forced reflow 제거)

## 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)