### PR TITLE
fix(ui): 사진 첨부 후 URL 노출 → 썸네일 표시

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -6,7 +6,7 @@ import { friendlyApiError } from '@/lib/auth-errors';
 import { toast } from '@/stores/toastStore';
 
 interface ChatInputProps {
-  onSend: (text: string) => void;
+  onSend: (text: string, imageUrl?: string) => void;
   disabled?: boolean;
   showChips?: boolean;
 }
@@ -66,15 +66,12 @@ export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInpu
     const trimmed = text.trim();
     if (!trimmed && !attachedImage) return;
 
-    let finalText = trimmed;
+    let uploadedUrl: string | undefined;
     if (attachedImage) {
       setUploading(true);
       try {
-        const { image_url } = await uploadApi.image(attachedImage);
-        // BE image_search_node 가 query 텍스트에서 https URL 을 regex 로 추출.
-        finalText = trimmed
-          ? `${trimmed}\n${image_url}`
-          : `이 사진과 비슷한 곳 추천해줘\n${image_url}`;
+        const res = await uploadApi.image(attachedImage);
+        uploadedUrl = res.image_url;
       } catch (err) {
         toast.error(friendlyApiError(err, '사진 업로드 실패'));
         setUploading(false);
@@ -84,7 +81,8 @@ export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInpu
       clearImage();
     }
 
-    onSend(finalText);
+    // text + imageUrl 분리해서 전달 — store 가 BE query 와 UI 표시용을 다르게 처리.
+    onSend(trimmed, uploadedUrl);
     setText('');
   };
 

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -97,8 +97,28 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
     <div ref={bubbleRef}>
       {isUser ? (
         <div className="flex justify-end pl-12">
-          <div className="bg-brand-subtle border border-brand/8 rounded-2xl rounded-br-sm px-3.5 py-2.5 text-[14px] leading-[1.6] text-text-primary">
-            {message.text}
+          <div className="flex flex-col items-end gap-1.5 max-w-[85%]">
+            {message.attachedImageUrl && (
+              <a
+                href={message.attachedImageUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block w-[180px] h-[180px] rounded-2xl rounded-br-sm overflow-hidden border border-brand/15 bg-bg-subtle"
+                aria-label="첨부 사진 원본 열기"
+              >
+                <img
+                  src={message.attachedImageUrl}
+                  alt="첨부 사진"
+                  loading="lazy"
+                  className="w-full h-full object-cover"
+                />
+              </a>
+            )}
+            {message.text && (
+              <div className="bg-brand-subtle border border-brand/8 rounded-2xl rounded-br-sm px-3.5 py-2.5 text-[14px] leading-[1.6] text-text-primary break-words">
+                {message.text}
+              </div>
+            )}
           </div>
         </div>
       ) : (

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -148,6 +148,17 @@ function messageItemToMessage(item: MessageItem, threadId: string): Message {
     }
   }
 
+  // user 메시지의 텍스트에 첨부 이미지 URL 이 inline 으로 끼어 있을 수 있음 (전송 흐름).
+  // UI 에선 thumb 으로 분리 표시 — text 에서 추출 + 제거.
+  let attachedImageUrl: string | undefined;
+  if (item.role !== 'assistant') {
+    const imgMatch = text.match(/(https?:\/\/[^\s]+\.(?:jpg|jpeg|png|webp)(?:\?[^\s]*)?)/i);
+    if (imgMatch) {
+      attachedImageUrl = imgMatch[0];
+      text = text.replace(imgMatch[0], '').replace(/이 사진과 비슷한 곳 추천해줘\s*$/, '').trim();
+    }
+  }
+
   return {
     id: String(item.message_id),
     role: item.role === 'assistant' ? 'agent' : 'user',
@@ -157,6 +168,7 @@ function messageItemToMessage(item: MessageItem, threadId: string): Message {
     itinerary,
     itineraries: itineraries.length > 1 ? itineraries : undefined,
     blocks: otherBlocks.length > 0 ? otherBlocks : undefined,
+    attachedImageUrl,
     threadId,
     messageId: item.message_id,
   };
@@ -188,7 +200,7 @@ interface ChatStore {
   chatsLoading: boolean;
   chatsError: string | null;
 
-  sendMessage: (text: string) => Promise<void>;
+  sendMessage: (text: string, imageUrl?: string) => Promise<void>;
   setAgent: (agent: AgentType) => void;
   clearChat: () => void;
   initWelcome: () => void;
@@ -231,14 +243,21 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set({ messages: [welcomeMsg] });
   },
 
-  sendMessage: async (text: string) => {
+  sendMessage: async (text: string, imageUrl?: string) => {
     const { selectedAgent, messages, sessionId, sessions } = get();
+
+    // BE 는 query 텍스트에서 regex 로 image URL 파싱 → 우리는 본문에 URL 을 끼워서 전송.
+    // 단 UI 에 보여주는 user message 는 텍스트 + 첨부 thumb 으로 분리.
+    const queryForBE = imageUrl
+      ? (text ? `${text}\n${imageUrl}` : `이 사진과 비슷한 곳 추천해줘\n${imageUrl}`)
+      : text;
 
     const userMsg: Message = {
       id: `msg-${Date.now()}`,
       role: 'user',
       text,
       timestamp: new Date().toISOString(),
+      attachedImageUrl: imageUrl,
     };
 
     const updatedMessages = [...messages, userMsg];
@@ -255,7 +274,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     let beMessageId: number | undefined;
 
     await new Promise<void>((resolve) => {
-      const conn = openChatStream(sessionId, text, {
+      const conn = openChatStream(sessionId, queryForBE, {
         text_stream: (data) => {
           if (data.type === 'text_stream') {
             acc += data.delta ?? data.content ?? '';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -96,6 +96,8 @@ export interface Message {
   threadId?: string;
   messageId?: string | number;
   blocks?: import('./api').Block[];
+  // 사용자 첨부 이미지 URL (BE 가 query 텍스트에서 regex 로 파싱하지만 UI 는 thumb 으로 표시).
+  attachedImageUrl?: string;
 }
 
 // === Agent Response ===


### PR DESCRIPTION
## 증상
사진 업로드 후 전송하면 사용자 버블에 GCS signed URL 이 raw 텍스트로 노출 (스크린샷 참조).

## 원인
ChatInput 이 'text + \n + URL' 합쳐서 sendMessage 호출 → userMsg.text 가 URL 포함 → 그대로 렌더.

## 수정
- Message 타입에 attachedImageUrl?: string 추가
- chatStore.sendMessage(text, imageUrl?) — BE query 만 URL 끼움, UI userMsg 는 분리 저장
- ChatInput: onSend(text, url) 별도 인자 전달
- MessageBubble user 변형: 첨부 이미지 thumb (180×180, 클릭 시 원본 새 탭), text 빈 경우 thumb 만
- messageItemToMessage (BE 응답 → Message): user 텍스트에서 image URL regex 추출 + '이 사진과 비슷한 곳 추천해줘' prefix 제거 → 새로고침 후에도 thumb 으로 보임

## 검증
- typecheck 0 errors
- 13/13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)