### PR TITLE
perf: 미사용 ScrollTrigger 제거 + 자동스크롤 reflow 완화

### DIFF
--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -12,9 +12,13 @@ export default memo(function ChatMessages() {
   const hasOnlyWelcome = messages.length <= 1;
 
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
+    // rAF 로 다음 프레임에 읽기/쓰기 — commit 단계에서 scrollHeight 를 동기로 읽어
+    // 강제 reflow 나던 것을 레이아웃 단계와 분리.
+    const id = requestAnimationFrame(() => {
+      const el = scrollRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+    return () => cancelAnimationFrame(id);
   }, [messages, isLoading]);
 
   return (

--- a/src/lib/gsap-setup.ts
+++ b/src/lib/gsap-setup.ts
@@ -1,12 +1,10 @@
-// GSAP 플러그인 등록 — 진입 시점에 1회. main.tsx 에서 import.
-// ScrollTrigger 외에 추가 플러그인이 생기면 여기에 register.
+// GSAP — 진입 시점에 1회 import. main.tsx 에서 로드.
+// (ScrollTrigger 는 미사용이라 제거: 전역 scroll/resize 리스너 + 등록 시 layout refresh 가
+//  로드 시 강제 reflow 를 유발하고 vendor-gsap 번들을 키웠음. 필요해지면 여기서 register.)
 
 import gsap from 'gsap';
-import { ScrollTrigger } from 'gsap/ScrollTrigger';
 
-gsap.registerPlugin(ScrollTrigger);
-
-export { gsap, ScrollTrigger };
+export { gsap };
 
 export function prefersReducedMotion(): boolean {
   return typeof window !== 'undefined' &&


### PR DESCRIPTION
## 배경
Lighthouse 트레이스에서 forced reflow(vendor-gsap 37ms, 메인 38ms)와 높은 Script Evaluation(1.8s) 확인. 조사 결과 `gsap/ScrollTrigger`가 진입 시 전역 등록되지만 **실사용 0건**(MessageBubble은 이미 IntersectionObserver로 전환).

## 작업 내용
- **미사용 ScrollTrigger 제거** (`gsap-setup.ts`)
  - 메인 청크에 포함돼 있던 ScrollTrigger 코드 제거
  - 등록 시 걸리던 전역 scroll/resize 리스너 + 초기 layout refresh(로드 시 forced reflow) 제거
- **ChatMessages 자동 스크롤을 `requestAnimationFrame` 으로 분리** — commit 단계에서 `scrollHeight` 동기 읽기로 나던 forced reflow 완화

## 효과 (production build)
- 메인 `index.js` gzip **112.53 KiB → 93.48 KiB** (−19 KiB)
- 누적(원본 157KB 대비): **−63.6 KiB gzip, ~40%↓**
- 로드 시 ScrollTrigger 발 forced reflow 제거

## 검증
- [x] `tsc --noEmit` 통과
- [x] `eslint` 통과
- [x] `vite build` 성공 (gsap 코어/애니메이션 정상 — ScrollTrigger만 미사용분 제거)

참고: 보고된 점수 하락(90→86)은 트레이스에 섞인 브라우저 확장(React DevTools `installHook.js`, ad-filtering, jquery) 영향 + 모바일 lab 변동성이 큼. 정확한 측정은 PageSpeed Insights 또는 시크릿(확장 off) 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)