### PR TITLE
feat: 공유(읽기전용) 페이지 지도 + 마크다운 렌더

### DIFF
--- a/src/components/share/SharedMap.tsx
+++ b/src/components/share/SharedMap.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import type { Place } from '@/types';
+import GoogleMap from '@/components/map/GoogleMap';
+
+// 공유(읽기 전용) 페이지용 경량 지도. 메시지의 장소/코스 마커를 표시하고
+// 탭하면 강조만 한다(편집/네비게이션 없음). SharedPage 에서 lazy 로드.
+export default function SharedMap({
+  places,
+  itineraryMode,
+}: {
+  places: Place[];
+  itineraryMode: boolean;
+}) {
+  const [selected, setSelected] = useState<Place | null>(null);
+  return (
+    <div className="h-[320px] w-full rounded-xl overflow-hidden border border-border">
+      <GoogleMap
+        markers={places}
+        selectedPlace={selected}
+        onSelectPlace={setSelected}
+        itineraryMode={itineraryMode}
+      />
+    </div>
+  );
+}

--- a/src/components/share/SharedPage.tsx
+++ b/src/components/share/SharedPage.tsx
@@ -1,16 +1,53 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, lazy, Suspense } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { sharedApi } from '@/lib/api';
 import { friendlyApiError } from '@/lib/auth-errors';
 import type { Block, SharedConversation } from '@/types/api';
+import type { Place } from '@/types';
 import { BlockRenderer } from '@/components/chat/blocks';
 import PlaceCarousel from '@/components/chat/PlaceCarousel';
 import ItineraryCard from '@/components/chat/ItineraryCard';
+import Markdown from '@/components/ui/Markdown';
 import {
   singlePlaceBlockToPlace,
   placesBlockToPlaces,
   courseBlockToItinerary,
 } from '@/stores/chatStore';
+
+// 지도(GoogleMap → 구글맵 JS) 는 지도 마커가 있는 메시지에서만 lazy 로드.
+const SharedMap = lazy(() => import('./SharedMap'));
+
+// 공유 메시지의 place/places/course 블록에서 유효 좌표 마커를 수집.
+function collectMapPlaces(blocks: Block[]): Place[] {
+  const out: Place[] = [];
+  for (const b of blocks) {
+    if (b.type === 'place') out.push(singlePlaceBlockToPlace(b));
+    else if (b.type === 'places') out.push(...placesBlockToPlaces(b));
+    else if (b.type === 'course') {
+      for (const s of courseBlockToItinerary(b).stops) {
+        if (s.lat != null && s.lng != null) {
+          out.push({
+            id: s.placeId,
+            name: s.placeName,
+            category: s.category ?? 'tourism',
+            address: s.address ?? '',
+            lat: s.lat,
+            lng: s.lng,
+            hours: '',
+            rating: s.rating ?? 0,
+            summary: '',
+            image: s.imageUrl,
+            congestion: s.congestion,
+          });
+        }
+      }
+    }
+  }
+  // (0,0) / NaN 좌표 제거 — 마커가 엉뚱한 곳에 찍히는 것 방지.
+  return out.filter(
+    (p) => Number.isFinite(p.lat) && Number.isFinite(p.lng) && (p.lat !== 0 || p.lng !== 0),
+  );
+}
 
 export default function SharedPage() {
   const { token } = useParams<{ token: string }>();
@@ -118,6 +155,9 @@ function SharedMessage({ role, blocks, createdAt }: { role: string; blocks: unkn
       b.type !== 'map_route',
   );
 
+  const mapPlaces = isUser ? [] : collectMapPlaces(typedBlocks);
+  const hasCourse = typedBlocks.some((b) => b.type === 'course');
+
   return (
     <div className={isUser ? 'self-end max-w-[85%]' : 'self-start w-full max-w-full'}>
       {text && (
@@ -125,10 +165,22 @@ function SharedMessage({ role, blocks, createdAt }: { role: string; blocks: unkn
           className={
             isUser
               ? 'bg-brand-subtle border border-brand rounded-2xl rounded-br-md px-4 py-2.5 text-sm whitespace-pre-wrap'
-              : 'bg-bg-warm border border-border rounded-2xl rounded-bl-md px-4 py-2.5 text-sm whitespace-pre-wrap leading-[1.6]'
+              : 'bg-bg-warm border border-border rounded-2xl rounded-bl-md px-4 py-2.5 text-sm leading-[1.6]'
           }
         >
-          {text}
+          {isUser ? text : <Markdown>{text}</Markdown>}
+        </div>
+      )}
+
+      {mapPlaces.length > 0 && (
+        <div className="mt-2.5">
+          <Suspense
+            fallback={
+              <div className="h-[320px] w-full rounded-xl border border-border bg-bg-subtle animate-pulse" />
+            }
+          >
+            <SharedMap places={mapPlaces} itineraryMode={hasCourse} />
+          </Suspense>
         </div>
       )}
 


### PR DESCRIPTION
## 작업 내용
- **읽기 전용 공유 페이지에 지도 추가**: 메시지의 `place`/`places`/`course` 블록에서 유효 좌표를 모아 읽기 전용 `GoogleMap` 표시 (코스는 polyline). (0,0)/NaN 좌표는 필터링.
  - `SharedMap` 컴포넌트를 `React.lazy` 로 분리 → 지도 마커가 있는 메시지에서만 구글맵 JS fetch (메인/공유 번들 영향 최소)
- **마크다운 렌더**: 어시스턴트 텍스트를 raw 출력 대신 `Markdown` 으로 렌더 → `**강조**` 가 그대로 보이던 문제 해결 (유저 메시지는 기존대로 plain)

## 검증
- [x] `tsc --noEmit` 통과
- [x] `eslint` 통과
- [x] `vite build` 성공 (SharedMap/GoogleMap 별도 lazy 청크, 메인 번들 93.49KB 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)