### PR TITLE
feat: 이미지리스 카테고리 카드 (이미지 없이 동작)

### DIFF
--- a/src/components/chat/ItineraryCard.tsx
+++ b/src/components/chat/ItineraryCard.tsx
@@ -72,6 +72,7 @@ export default function ItineraryCard({ itinerary, hideActions = false }: { itin
           // 카테고리는 stop.category(BE) → mock → 'tourism' 우선순위로 결정.
           // 지도 패널과 동일 helper 를 써서 양쪽 일관성 보장.
           const cat = CATEGORY_CONFIG[deriveStopCategory(stop)];
+          const CatIcon = cat.icon;
           const isLast = i >= itinerary.stops.length - 1;
           const TransportIcon = !isLast ? TRANSPORT_ICON[stop.transportToNext] : null;
 
@@ -102,12 +103,7 @@ export default function ItineraryCard({ itinerary, hideActions = false }: { itin
                         loading="lazy"
                       />
                     ) : (
-                      <span
-                        className="text-[22px] font-semibold"
-                        style={{ color: cat?.color ?? 'var(--color-text-muted)' }}
-                      >
-                        {cat?.label[0] ?? '·'}
-                      </span>
+                      <CatIcon size={24} strokeWidth={1.8} style={{ color: cat.color }} aria-hidden="true" />
                     )}
                   </div>
                   {/* Order badge — 외부 컨테이너에 absolute, 음수 offset으로 모서리 바깥으로 */}

--- a/src/components/chat/PlaceCard.tsx
+++ b/src/components/chat/PlaceCard.tsx
@@ -7,6 +7,7 @@ import { useMapStore } from '@/stores/mapStore';
 import { useBookmarkStore } from '@/stores/bookmarkStore';
 import { flipToMarker } from '@/lib/flip-to-marker';
 import BookingForm from '@/components/booking/BookingForm';
+import Markdown from '@/components/ui/Markdown';
 
 function prefersReducedMotion(): boolean {
   return typeof window !== 'undefined' &&
@@ -34,6 +35,7 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
   const articleRef = useRef<HTMLElement>(null);
 
   const cat = CATEGORY_CONFIG[place.category];
+  const CatIcon = cat.icon;
 
   const handleViewOnMap = () => {
     if (articleRef.current) {
@@ -85,83 +87,64 @@ export default function PlaceCard({ place, compact }: PlaceCardProps) {
         tabIndex={0}
         className="group bg-bg-surface border border-border rounded-2xl overflow-hidden transition-[border-color,box-shadow,transform] duration-200 hover:shadow-md hover:border-border-strong hover:-translate-y-[1px] cursor-pointer"
       >
-        <div className="relative aspect-video bg-bg-subtle overflow-hidden">
-          {place.image && (
-            <img
-              src={place.image}
-              alt={place.name}
-              loading="lazy"
-              className="absolute inset-0 w-full h-full object-cover"
-              onError={(e) => {
-                // 이미지 로드 실패 시 카테고리 색 placeholder로 대체
-                (e.currentTarget as HTMLImageElement).style.display = 'none';
-              }}
-            />
-          )}
-          <span
-            className="absolute top-3 left-3 z-10 px-2 py-0.5 rounded-full text-[11px] font-medium"
-            style={{ backgroundColor: `${cat.color}14`, color: cat.color }}
-          >
-            {cat.label}
-          </span>
-          <div className="absolute top-3 right-3 z-10 flex flex-col items-end gap-1">
-            <div className="flex items-center gap-1.5">
-              {place.rating > 0 && (
-                <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-bg-surface/90 text-text-primary backdrop-blur-sm tabular-nums">
-                  <Star size={10} fill="currentColor" className="text-amber-500" aria-hidden="true" />
-                  {place.rating}
-                </span>
-              )}
-              <button
-                ref={bookmarkBtnRef}
-                onClick={handleBookmark}
-                className="relative w-7 h-7 rounded-full flex items-center justify-center bg-bg-surface/90 backdrop-blur-sm hover:scale-110 cursor-pointer"
-                aria-label={isBookmarked ? '북마크 해제' : '북마크'}
-                aria-pressed={isBookmarked}
-              >
-                <Bookmark
-                  size={13}
-                  strokeWidth={isBookmarked ? 0 : 1.8}
-                  fill={isBookmarked ? '#F59E0B' : 'none'}
-                  className={isBookmarked ? '' : 'text-text-primary'}
-                />
-                <span ref={burstRef} className="pointer-events-none absolute inset-0" aria-hidden="true">
-                  {[0, 1, 2, 3, 4, 5].map((i) => (
-                    <span
-                      key={i}
-                      className="bm-particle absolute top-1/2 left-1/2 w-1 h-1 -ml-0.5 -mt-0.5 rounded-full bg-amber-400 opacity-0"
-                    />
-                  ))}
-                </span>
-              </button>
-            </div>
-            {place.congestion && (
-              <div className="flex flex-col items-end gap-0.5">
-                <span
-                  className={`px-2 py-0.5 rounded-full text-[11px] font-medium ${CONGESTION_BADGE[place.congestion.level].className}`}
-                >
-                  {CONGESTION_BADGE[place.congestion.level].label}
-                </span>
-                {place.congestion.updatedAt && (
-                  <span className="text-[10px] text-gray-400">기준: {place.congestion.updatedAt}</span>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-
         <div className="px-3.5 py-3">
+          {/* 헤더 행 — 이미지리스: 카테고리 아이콘 칩 + 별점/혼잡도 + 북마크 */}
+          <div className="flex items-center gap-2 mb-2">
+            <span
+              className="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg text-[11px] font-medium shrink-0"
+              style={{ backgroundColor: `${cat.color}14`, color: cat.color }}
+            >
+              <CatIcon size={13} strokeWidth={2} aria-hidden="true" />
+              {cat.label}
+            </span>
+            {place.rating > 0 && (
+              <span className="flex items-center gap-1 text-[12px] text-text-secondary tabular-nums">
+                <Star size={11} fill="currentColor" className="text-amber-500" aria-hidden="true" />
+                {place.rating}
+              </span>
+            )}
+            {place.congestion && (
+              <span
+                className={`px-1.5 py-0.5 rounded-md text-[11px] font-medium ${CONGESTION_BADGE[place.congestion.level].className}`}
+              >
+                지금 {CONGESTION_BADGE[place.congestion.level].label}
+              </span>
+            )}
+            <button
+              ref={bookmarkBtnRef}
+              onClick={handleBookmark}
+              className="relative ml-auto w-7 h-7 rounded-full flex items-center justify-center hover:bg-bg-subtle hover:scale-110 cursor-pointer shrink-0"
+              aria-label={isBookmarked ? '북마크 해제' : '북마크'}
+              aria-pressed={isBookmarked}
+            >
+              <Bookmark
+                size={14}
+                strokeWidth={isBookmarked ? 0 : 1.8}
+                fill={isBookmarked ? '#F59E0B' : 'none'}
+                className={isBookmarked ? '' : 'text-text-primary'}
+              />
+              <span ref={burstRef} className="pointer-events-none absolute inset-0" aria-hidden="true">
+                {[0, 1, 2, 3, 4, 5].map((i) => (
+                  <span
+                    key={i}
+                    className="bm-particle absolute top-1/2 left-1/2 w-1 h-1 -ml-0.5 -mt-0.5 rounded-full bg-amber-400 opacity-0"
+                  />
+                ))}
+              </span>
+            </button>
+          </div>
+
           <h4 className="text-[14px] font-semibold text-text-primary tracking-[-0.02em] leading-tight truncate">
             {place.name}
           </h4>
-          <div className="flex items-center gap-1 mt-1.5 text-[12px] text-text-muted min-w-0">
+          <div className="flex items-center gap-1 mt-1 text-[12px] text-text-muted min-w-0">
             <MapPin size={11} strokeWidth={1.5} aria-hidden="true" />
             <span className="truncate">{place.address}</span>
           </div>
-          {!compact && (
-            <p className="text-[13px] text-text-primary mt-2 leading-[1.6] line-clamp-2">
+          {!compact && place.summary && (
+            <Markdown inline className="block text-[13px] text-text-primary mt-2 leading-[1.6] line-clamp-2">
               {place.summary}
-            </p>
+            </Markdown>
           )}
           {(place.naverMapUrl || place.kakaoMapUrl) && (
             <div className="flex items-center gap-2 mt-2">

--- a/src/components/chat/PlaceCarousel.tsx
+++ b/src/components/chat/PlaceCarousel.tsx
@@ -20,6 +20,7 @@ interface PlaceCardTileProps {
 
 function PlaceCardTile({ place, variant, onSelect }: PlaceCardTileProps) {
   const cat = CATEGORY_CONFIG[place.category];
+  const CatIcon = cat.icon;
   const bookmarkedIds = useBookmarkStore((s) => s.bookmarkedIds);
   const toggleBookmark = useBookmarkStore((s) => s.toggle);
   const isBookmarked = bookmarkedIds.includes(place.id);
@@ -40,50 +41,43 @@ function PlaceCardTile({ place, variant, onSelect }: PlaceCardTileProps) {
       tabIndex={0}
       aria-label={`${place.name} - ${cat.label}`}
     >
-      <div className="relative aspect-video bg-bg-subtle overflow-hidden">
-        {place.image && (
-          <img
-            src={place.image}
-            alt={place.name}
-            loading="lazy"
-            className="absolute inset-0 w-full h-full object-cover"
-            onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
-          />
-        )}
-        <span
-          className="absolute top-2 left-2 z-10 px-2 py-0.5 rounded-full text-[11px] font-medium"
-          style={{ backgroundColor: `${cat.color}14`, color: cat.color }}
-        >
-          {cat.label}
-        </span>
-        <button
-          type="button"
-          onClick={handleBookmark}
-          className="absolute top-2 right-2 z-10 w-7 h-7 rounded-full flex items-center justify-center bg-bg-surface/90 backdrop-blur-sm transition-all duration-200 hover:scale-110 active:scale-95 cursor-pointer"
-          aria-label={isBookmarked ? '북마크 해제' : '북마크'}
-          aria-pressed={isBookmarked}
-        >
-          <Bookmark
-            size={12}
-            strokeWidth={isBookmarked ? 0 : 1.8}
-            fill={isBookmarked ? '#F59E0B' : 'none'}
-            className={isBookmarked ? '' : 'text-text-primary'}
-          />
-        </button>
-        {place.congestion && (
-          <span
-            className="absolute bottom-2 left-2 z-10 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10.5px] font-medium backdrop-blur-sm"
-            style={{
-              backgroundColor: CONGESTION_CONFIG[place.congestion.level].bg,
-              color: CONGESTION_CONFIG[place.congestion.level].color,
-            }}
-          >
-            <Users size={9} strokeWidth={2} aria-hidden="true" />
-            지금 {CONGESTION_CONFIG[place.congestion.level].label}
-          </span>
-        )}
-      </div>
       <div className="p-3">
+        {/* 헤더 — 이미지리스: 카테고리 아이콘 칩 + 혼잡도 + 북마크 */}
+        <div className="flex items-center gap-1.5 mb-1.5">
+          <span
+            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[11px] font-medium shrink-0"
+            style={{ backgroundColor: `${cat.color}14`, color: cat.color }}
+          >
+            <CatIcon size={12} strokeWidth={2} aria-hidden="true" />
+            {cat.label}
+          </span>
+          {place.congestion && (
+            <span
+              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10.5px] font-medium shrink-0"
+              style={{
+                backgroundColor: CONGESTION_CONFIG[place.congestion.level].bg,
+                color: CONGESTION_CONFIG[place.congestion.level].color,
+              }}
+            >
+              <Users size={9} strokeWidth={2} aria-hidden="true" />
+              지금 {CONGESTION_CONFIG[place.congestion.level].label}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={handleBookmark}
+            className="ml-auto w-7 h-7 rounded-full flex items-center justify-center hover:bg-bg-subtle transition-all duration-200 hover:scale-110 active:scale-95 cursor-pointer shrink-0"
+            aria-label={isBookmarked ? '북마크 해제' : '북마크'}
+            aria-pressed={isBookmarked}
+          >
+            <Bookmark
+              size={13}
+              strokeWidth={isBookmarked ? 0 : 1.8}
+              fill={isBookmarked ? '#F59E0B' : 'none'}
+              className={isBookmarked ? '' : 'text-text-primary'}
+            />
+          </button>
+        </div>
         <h4 className="text-[14px] font-semibold text-text-primary truncate">{place.name}</h4>
         <div className="flex items-center gap-1 mt-1 text-[11px] text-text-muted">
           {place.rating > 0 && (

--- a/src/components/map/ItineraryStopsList.tsx
+++ b/src/components/map/ItineraryStopsList.tsx
@@ -44,6 +44,7 @@ export default memo(function ItineraryStopsList({ navigation, onStopSelect }: Pr
             <div className="space-y-3">
               {stops.map((stop, idxInSection) => {
                 const cat = CATEGORY_CONFIG[deriveStopCategory(stop)];
+                const CatIcon = cat.icon;
                 const isCurrent = itinerary.stops[stopIndex]?.placeId === stop.placeId;
                 const isSelected = selectedPlace?.id === stop.placeId;
                 const globalIdx = itinerary.stops.findIndex((s) => s.placeId === stop.placeId);
@@ -74,9 +75,7 @@ export default memo(function ItineraryStopsList({ navigation, onStopSelect }: Pr
                           loading="lazy"
                         />
                       ) : (
-                        <span className="text-[24px]" style={{ color: cat.color }}>
-                          {cat.label[0]}
-                        </span>
+                        <CatIcon size={28} strokeWidth={1.8} style={{ color: cat.color }} aria-hidden="true" />
                       )}
                     </div>
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import type { AgentType, PlaceCategory, TransportMode, CongestionLevel } from '@/types';
+import { Landmark, ShoppingBag, Palette, Utensils, type LucideIcon } from 'lucide-react';
 
 export const AGENT_CONFIG: Record<AgentType, { label: string; color: string; company: string; desc: string }> = {
   claude: { label: 'Claude', color: '#1F3A8B', company: 'Anthropic', desc: '섬세한 추천' },
@@ -12,11 +13,11 @@ export const AGENT_COLORS: Record<AgentType, string> = {
   gemini: '#F4A12C',
 };
 
-export const CATEGORY_CONFIG: Record<PlaceCategory, { label: string; color: string }> = {
-  tourism: { label: '관광', color: '#1F3A8B' },
-  shopping: { label: '쇼핑', color: '#DC2127' },
-  culture: { label: '문화', color: '#F4A12C' },
-  food: { label: '음식', color: '#00853E' },
+export const CATEGORY_CONFIG: Record<PlaceCategory, { label: string; color: string; icon: LucideIcon }> = {
+  tourism: { label: '관광', color: '#1F3A8B', icon: Landmark },
+  shopping: { label: '쇼핑', color: '#DC2127', icon: ShoppingBag },
+  culture: { label: '문화', color: '#F4A12C', icon: Palette },
+  food: { label: '음식', color: '#00853E', icon: Utensils },
 };
 
 // BE가 보내는 카테고리 문자열(한글/영문 혼재)을 FE 4분류 enum으로 정규화.


### PR DESCRIPTION
## 배경
추천/장소 데이터에 이미지가 사실상 없어, 기존 카드의 16:9 이미지 영역이 빈 회색 박스로 노출됨. 이미지 없는 것을 **기본 전제**로 카드를 재설계.

## 작업 내용
- **CATEGORY_CONFIG 아이콘 추가**: 관광 `Landmark` / 쇼핑 `ShoppingBag` / 문화 `Palette` / 음식 `Utensils`
- **PlaceCard / PlaceCarousel 타일**: `aspect-video` 미디어 블록 제거 → 컴팩트 레이아웃
  - 헤더 행: 카테고리 아이콘 칩 + 별점 + 혼잡도 pill + 북마크
  - 이름 → 주소 → 요약(Markdown, 2줄 클램프) → (PlaceCard) 액션
- **코스 통일**: `ItineraryCard`·`ItineraryStopsList` 썸네일의 '첫 글자(관/쇼/문/음)' 폴백을 카테고리 아이콘으로 교체
- 이미지가 들어오는 경우의 `<img>` 경로는 유지(혹시 모를 대비), 폴백만 이미지리스로 전환

## 검증
- [x] `tsc --noEmit` 통과
- [x] `eslint` 통과
- [x] `vite build` 성공 (메인 번들 ~94KB, 영향 미미)

참고: SharedPage 는 PlaceCarousel/ItineraryCard 를 그대로 사용하므로 읽기 전용 페이지에도 자동 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)