### PR TITLE
feat: 질문 취소 버튼 + 입력 텍스트 복원

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useRef, useEffect, type FormEvent, type KeyboardEvent, type ChangeEvent } from 'react';
-import { ArrowUp, Image as ImageIcon, X } from 'lucide-react';
+import { ArrowUp, Image as ImageIcon, X, Square } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { uploadApi } from '@/lib/api';
 import { friendlyApiError } from '@/lib/auth-errors';
@@ -9,6 +9,12 @@ interface ChatInputProps {
   onSend: (text: string, imageUrl?: string) => void;
   disabled?: boolean;
   showChips?: boolean;
+  // 응답 생성 중 — 전송 버튼 자리를 '중단' 버튼으로 교체.
+  loading?: boolean;
+  onCancel?: () => void;
+  // 취소 시 스토어가 되돌려준 텍스트 → 입력창에 복원 후 onDraftRestored 로 1회 소비.
+  draftRestore?: string | null;
+  onDraftRestored?: () => void;
 }
 
 const EXAMPLE_CHIPS = [
@@ -21,7 +27,7 @@ const EXAMPLE_CHIPS = [
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 const MAX_BYTES = 10 * 1024 * 1024;
 
-export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInputProps) {
+export default memo(function ChatInput({ onSend, disabled, showChips, loading, onCancel, draftRestore, onDraftRestored }: ChatInputProps) {
   const [text, setText] = useState('');
   const [focused, setFocused] = useState(false);
   const [attachedImage, setAttachedImage] = useState<File | null>(null);
@@ -36,6 +42,14 @@ export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInpu
       if (previewUrl) URL.revokeObjectURL(previewUrl);
     };
   }, [previewUrl]);
+
+  // 취소 시 되돌아온 텍스트를 입력창에 복원 + 포커스. 1회 소비 후 스토어 플래그 초기화.
+  useEffect(() => {
+    if (draftRestore == null) return;
+    setText(draftRestore);
+    onDraftRestored?.();
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [draftRestore, onDraftRestored]);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -180,23 +194,35 @@ export default memo(function ChatInput({ onSend, disabled, showChips }: ChatInpu
             )}
             aria-label="메시지 입력"
           />
-          <button
-            type="submit"
-            disabled={!canSend}
-            className={cn(
-              'w-8 h-8 rounded-[10px] flex items-center justify-center transition-all duration-200 cursor-pointer shrink-0',
-              canSend
-                ? 'bg-brand text-white shadow-xs hover:bg-brand-hover active:scale-95'
-                : 'bg-bg-subtle text-text-muted',
-            )}
-            aria-label={uploading ? '업로드 중' : '전송'}
-          >
-            {uploading ? (
-              <div className="w-3.5 h-3.5 border-2 border-white/60 border-t-white rounded-full animate-spin" />
-            ) : (
-              <ArrowUp size={15} strokeWidth={2.5} />
-            )}
-          </button>
+          {loading ? (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="w-8 h-8 rounded-[10px] flex items-center justify-center bg-bg-subtle text-text-primary hover:bg-border transition-all duration-200 cursor-pointer shrink-0 active:scale-95"
+              aria-label="응답 생성 중단"
+              title="중단"
+            >
+              <Square size={12} fill="currentColor" strokeWidth={0} />
+            </button>
+          ) : (
+            <button
+              type="submit"
+              disabled={!canSend}
+              className={cn(
+                'w-8 h-8 rounded-[10px] flex items-center justify-center transition-all duration-200 cursor-pointer shrink-0',
+                canSend
+                  ? 'bg-brand text-white shadow-xs hover:bg-brand-hover active:scale-95'
+                  : 'bg-bg-subtle text-text-muted',
+              )}
+              aria-label={uploading ? '업로드 중' : '전송'}
+            >
+              {uploading ? (
+                <div className="w-3.5 h-3.5 border-2 border-white/60 border-t-white rounded-full animate-spin" />
+              ) : (
+                <ArrowUp size={15} strokeWidth={2.5} />
+              )}
+            </button>
+          )}
         </div>
       </form>
     </div>

--- a/src/components/chat/ChatInputConnected.tsx
+++ b/src/components/chat/ChatInputConnected.tsx
@@ -4,12 +4,23 @@ import ChatInput from './ChatInput';
 
 export default memo(function ChatInputConnected() {
   const sendMessage = useChatStore((s) => s.sendMessage);
+  const cancelMessage = useChatStore((s) => s.cancelMessage);
   const isLoading = useChatStore((s) => s.isLoading);
+  const draftRestore = useChatStore((s) => s.draftRestore);
+  const clearDraftRestore = useChatStore((s) => s.clearDraftRestore);
   const hasOnlyWelcome = useChatStore((s) => s.messages.length <= 1);
 
   return (
     <div className="shrink-0 border-t border-border bg-bg-surface/90 backdrop-blur-md">
-      <ChatInput onSend={sendMessage} disabled={isLoading} showChips={hasOnlyWelcome} />
+      <ChatInput
+        onSend={sendMessage}
+        disabled={isLoading}
+        loading={isLoading}
+        onCancel={cancelMessage}
+        draftRestore={draftRestore}
+        onDraftRestored={clearDraftRestore}
+        showChips={hasOnlyWelcome}
+      />
     </div>
   );
 });

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -9,6 +9,10 @@ import { friendlyApiError } from '@/lib/auth-errors';
 import { normalizeCategory } from '@/lib/utils';
 import { useMapStore } from './mapStore';
 
+// 진행 중 SSE 의 Promise resolve 참조 — cancelMessage 가 대기 중 Promise 를 깨우는 용도.
+// 동시에 하나의 스트림만 활성이므로 모듈 스코프로 충분(스토어 상태에 둘 필요 없음).
+let activeResolve: (() => void) | null = null;
+
 // SSE 블록 → 레거시 Message 타입 어댑터.
 
 export function singlePlaceBlockToPlace(it: PlaceBlockData): Place {
@@ -208,7 +212,14 @@ interface ChatStore {
   chatsLoading: boolean;
   chatsError: string | null;
 
+  // 진행 중 스트림 핸들(취소용) + 취소 시 입력창에 되돌릴 텍스트.
+  activeConn: { close: () => void } | null;
+  draftRestore: string | null;
+
   sendMessage: (text: string, imageUrl?: string) => Promise<void>;
+  // 진행 중 질문 취소 — 스트림 중단, 내 질문 말풍선 제거, 텍스트를 입력창으로 복원.
+  cancelMessage: () => void;
+  clearDraftRestore: () => void;
   setAgent: (agent: AgentType) => void;
   clearChat: () => void;
   initWelcome: () => void;
@@ -237,6 +248,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   sessions: [],
   chatsLoading: false,
   chatsError: null,
+  activeConn: null,
+  draftRestore: null,
 
   initWelcome: () => {
     const { selectedAgent, messages } = get();
@@ -282,6 +295,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     let beMessageId: number | undefined;
 
     await new Promise<void>((resolve) => {
+      activeResolve = resolve;
       const conn = openChatStream(sessionId, queryForBE, {
         text_stream: (data) => {
           if (data.type === 'text_stream') {
@@ -358,7 +372,13 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           }
         },
       });
+      set({ activeConn: conn });
     });
+
+    activeResolve = null;
+    // 취소된 경우 — cancelMessage 가 activeConn 을 null 로 비우고 상태를 이미 정리했으므로
+    // agent 메시지/세션 빌드 없이 종료(부분 답변이 thread 에 남지 않게).
+    if (get().activeConn === null) return;
 
     const agentId = `msg-${Date.now()}-agent`;
     const agentMsg: Message = {
@@ -403,6 +423,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       streamingText: '',
       currentStatus: '',
       sessions: updatedSessions,
+      activeConn: null,
     });
 
     // BE가 thread 자동 제목 생성을 안 해주는 우회 — 첫 메시지 응답 후 로컬 title을 서버에 push.
@@ -411,6 +432,30 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       chatsApi.rename(sessionId, session.title).catch(() => {});
     }
   },
+
+  cancelMessage: () => {
+    const { activeConn, messages } = get();
+    if (!activeConn) return;
+    activeConn.close();
+
+    // 진행 중 질문은 항상 messages 의 마지막(아직 agent 응답 미추가) → 제거 + 텍스트 복원.
+    const last = messages[messages.length - 1];
+    const restore = last?.role === 'user' ? last.text : '';
+    set({
+      messages: restore ? messages.slice(0, -1) : messages,
+      isLoading: false,
+      streamingText: '',
+      currentStatus: '',
+      activeConn: null,
+      draftRestore: restore || null,
+    });
+
+    // 대기 중이던 sendMessage Promise 를 깨워 마무리(가드에서 early-return).
+    activeResolve?.();
+    activeResolve = null;
+  },
+
+  clearDraftRestore: () => set({ draftRestore: null }),
 
   setAgent: (agent: AgentType) => {
     const { messages, sessionId, sessions } = get();


### PR DESCRIPTION
## 작업 내용
응답 생성 중 **전송 버튼 자리**를 '중단' 버튼으로 교체. 취소하면 진행 중 SSE 를 중단하고, 방금 보낸 질문 말풍선/부분 답변을 제거한 뒤 **입력했던 텍스트를 입력창으로 복원**해 바로 수정·재전송 가능.

- `chatStore`: `activeConn`(진행 중 스트림 핸들) + `draftRestore` 상태, `cancelMessage`/`clearDraftRestore` 액션 추가. `sendMessage` 가 취소 시 부분 답변을 thread 에 남기지 않도록 가드(`activeConn === null` early-return).
- `ChatInput`: `loading` 시 `Square`(중단) 버튼으로 분기(type=button), `draftRestore` 복원 effect(텍스트 set + 포커스).
- `ChatInputConnected`: 와이어링.

## 동작
1. 전송 → 입력창 비워지고 버튼이 ■(중단)으로 전환
2. 중단 클릭 → 스트림 중단 + 내 질문 제거 + 텍스트 복원 + 전송 버튼 복귀

## 범위/참고
- 텍스트만 복원(업로드 후 이미지 File 은 복원 대상 제외). 이미지 업로드 중 취소는 별도(후속, uploadApi AbortController 필요).

## 검증
- [x] `tsc --noEmit` 통과
- [x] `eslint` 통과
- [x] `vite build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)