### PR TITLE
feat: 북마크 메시지로 정확히 스크롤 (around/cursor 폴백)

### DIFF
--- a/src/components/bookmark/BookmarkPanel.tsx
+++ b/src/components/bookmark/BookmarkPanel.tsx
@@ -260,7 +260,7 @@ function MessageBookmarks({ items, onClose }: { items: MessageBookmarkItem[]; on
           <article
             key={item.bookmarkId}
             className="group relative bg-bg-surface border border-border rounded-2xl p-3.5 transition-all duration-200 hover:border-border-strong hover:shadow-sm cursor-pointer"
-            onClick={() => { loadSession(item.conversationId); onClose?.(); }}
+            onClick={() => { loadSession(item.conversationId, { focusMessageId: item.messageId }); onClose?.(); }}
           >
             <div className="flex items-center gap-2 mb-2">
               {pinChip && (

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -8,18 +8,77 @@ export default memo(function ChatMessages() {
   const messages = useChatStore((s) => s.messages);
   const isLoading = useChatStore((s) => s.isLoading);
 
+  const focusMessageId = useChatStore((s) => s.focusMessageId);
+  const clearFocusMessageId = useChatStore((s) => s.clearFocusMessageId);
+
   const scrollRef = useRef<HTMLDivElement>(null);
   const hasOnlyWelcome = messages.length <= 1;
 
   useEffect(() => {
-    // rAF 로 다음 프레임에 읽기/쓰기 — commit 단계에서 scrollHeight 를 동기로 읽어
-    // 강제 reflow 나던 것을 레이아웃 단계와 분리.
+    // 북마크 점프(focus) 진행 중이면 하단 자동스크롤을 건너뛴다(타겟 스크롤과 충돌 방지).
+    // focusMessageId 는 deps 에서 제외 — 소비(null) 시 이 effect 가 재실행돼 하단으로
+    // 튕기는 것을 막고, 다음 '새 메시지'(messages 변경) 때 정상 하단 스크롤되게 한다.
+    if (useChatStore.getState().focusMessageId) return;
     const id = requestAnimationFrame(() => {
       const el = scrollRef.current;
       if (el) el.scrollTop = el.scrollHeight;
     });
     return () => cancelAnimationFrame(id);
   }, [messages, isLoading]);
+
+  // 북마크에서 점프한 메시지로 스크롤 + 하이라이트. lazy 카드(코스/장소)가 뒤늦게 mount 되며
+  // 높이가 늘어나므로 ResizeObserver 로 ~900ms 동안 재정렬한 뒤 focus 를 소비한다.
+  useEffect(() => {
+    if (!focusMessageId) return;
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+
+    let cancelled = false;
+    let ro: ResizeObserver | null = null;
+    let settleTimer = 0;
+
+    const findEl = () =>
+      scroller.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(focusMessageId)}"]`);
+    const align = () => {
+      const el = findEl();
+      if (el) el.scrollIntoView({ block: 'center', behavior: 'auto' });
+      return el;
+    };
+
+    const raf = requestAnimationFrame(() => {
+      if (cancelled) return;
+      const el = align();
+      if (!el) {
+        // 타겟을 못 찾음(이론상 store 가 이미 검증하지만 방어적) → 소비만.
+        clearFocusMessageId();
+        return;
+      }
+      // 잠깐 강조 — 어느 버블인지 즉시 인지되게.
+      el.style.transition = 'box-shadow 0.25s ease';
+      el.style.borderRadius = '14px';
+      el.style.boxShadow = '0 0 0 2px var(--color-brand)';
+      window.setTimeout(() => {
+        el.style.boxShadow = '';
+      }, 1600);
+
+      // lazy 카드 높이 변동 추적 재정렬.
+      ro = new ResizeObserver(() => {
+        if (!cancelled) align();
+      });
+      ro.observe(el);
+      settleTimer = window.setTimeout(() => {
+        ro?.disconnect();
+        clearFocusMessageId();
+      }, 900);
+    });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      ro?.disconnect();
+      window.clearTimeout(settleTimer);
+    };
+  }, [focusMessageId, messages, clearFocusMessageId]);
 
   return (
     <div ref={scrollRef} data-chat-scroller className="flex-1 overflow-y-auto overscroll-contain">

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -98,7 +98,10 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
   }, [message, beMessageIdStr, conversationId, toggleMessage]);
 
   return (
-    <div ref={bubbleRef}>
+    <div
+      ref={bubbleRef}
+      data-message-id={message.messageId != null ? String(message.messageId) : undefined}
+    >
       {isUser ? (
         <div className="flex justify-end pl-12">
           <div className="flex flex-col items-end gap-1.5 max-w-[85%]">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -314,7 +314,9 @@ export const chatsApi = {
     request<ChatListResponse>(buildUrl('/api/v1/chats', params)),
   detail: (thread_id: string) =>
     request<ChatDetailResponse>(`/api/v1/chats/${encodeURIComponent(thread_id)}`),
-  messages: (thread_id: string, params?: { cursor?: string; limit?: number }) =>
+  // around: 특정 message_id 주변 메시지 윈도우 요청(BE 지원 시). 미지원이면 무시되고
+  // FE 가 cursor 페이지네이션으로 폴백 탐색한다(loadSession 참고).
+  messages: (thread_id: string, params?: { cursor?: string; limit?: number; around?: string }) =>
     request<MessageListResponse>(buildUrl(`/api/v1/chats/${encodeURIComponent(thread_id)}/messages`, params)),
   rename: (thread_id: string, title: string) =>
     request<{ thread_id: string; title: string; updated_at: string }>(

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -216,6 +216,9 @@ interface ChatStore {
   activeConn: { close: () => void } | null;
   draftRestore: string | null;
 
+  // 북마크에서 특정 메시지로 점프 시, 스크롤 대상 message_id(문자열). 소비 후 null.
+  focusMessageId: string | null;
+
   sendMessage: (text: string, imageUrl?: string) => Promise<void>;
   // 진행 중 질문 취소 — 스트림 중단, 내 질문 말풍선 제거, 텍스트를 입력창으로 복원.
   cancelMessage: () => void;
@@ -224,7 +227,8 @@ interface ChatStore {
   clearChat: () => void;
   initWelcome: () => void;
   newChat: () => void;
-  loadSession: (sessionId: string) => Promise<void>;
+  loadSession: (sessionId: string, opts?: { focusMessageId?: string }) => Promise<void>;
+  clearFocusMessageId: () => void;
   deleteSession: (sessionId: string) => Promise<void>;
   renameSession: (sessionId: string, title: string) => Promise<void>;
   // BE에서 thread 목록 동기화. 비로그인/실패 시 silent하지만 chatsError를 채움.
@@ -250,6 +254,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   chatsError: null,
   activeConn: null,
   draftRestore: null,
+  focusMessageId: null,
 
   initWelcome: () => {
     const { selectedAgent, messages } = get();
@@ -525,12 +530,38 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     }, 0);
   },
 
-  loadSession: async (id: string) => {
+  loadSession: async (id: string, opts?: { focusMessageId?: string }) => {
     const { sessions, selectedAgent } = get();
     const existing = sessions.find((s) => s.id === id);
+    const focusId = opts?.focusMessageId ?? null;
     try {
-      const res = await chatsApi.messages(id, { limit: 100 });
-      const messages = res.items.map((it) => messageItemToMessage(it, id));
+      // around 지원 BE 면 타겟 주변 윈도우를, 아니면 최신 100개를 받음.
+      const first = await chatsApi.messages(id, {
+        limit: 100,
+        ...(focusId ? { around: focusId } : {}),
+      });
+      const byId = new Map<string, ReturnType<typeof messageItemToMessage>>();
+      const add = (its: typeof first.items) => {
+        for (const it of its) byId.set(String(it.message_id), messageItemToMessage(it, id));
+      };
+      add(first.items);
+
+      // 폴백: around 미지원 등으로 타겟이 안 잡히면 cursor 로 과거 페이지를 더 로드(최대 N페이지).
+      let cursor = first.next_cursor;
+      if (focusId && !byId.has(focusId)) {
+        const MAX_PAGES = 9; // 100 + 9*100 = 최대 1000개까지 탐색
+        for (let i = 0; cursor && i < MAX_PAGES && !byId.has(focusId); i += 1) {
+          const next = await chatsApi.messages(id, { limit: 100, cursor });
+          add(next.items);
+          cursor = next.next_cursor;
+        }
+      }
+
+      // cursor 방향(과거/미래)에 의존하지 않도록 created_at 오름차순으로 정렬.
+      const messages = [...byId.values()].sort(
+        (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+      );
+
       const now = new Date().toISOString();
       const session: ChatSession = existing
         ? { ...existing, messages, updatedAt: now }
@@ -541,6 +572,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         selectedAgent: session.agent,
         streamingText: '',
         isLoading: false,
+        // 타겟이 실제 로드됐을 때만 focus 설정 — 못 찾으면 null(폴백: 자동 하단 스크롤).
+        focusMessageId: focusId && byId.has(focusId) ? focusId : null,
         sessions: existing
           ? sessions.map((s) => (s.id === id ? session : s))
           : [session, ...sessions],
@@ -554,10 +587,13 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           selectedAgent: existing.agent,
           streamingText: '',
           isLoading: false,
+          focusMessageId: focusId && existing.messages.some((m) => String(m.messageId) === focusId) ? focusId : null,
         });
       }
     }
   },
+
+  clearFocusMessageId: () => set({ focusMessageId: null }),
 
   deleteSession: async (id: string) => {
     // Optimistic — 로컬에서 즉시 제거. BE 실패해도 다음 loadFromServer에서 복원됨.


### PR DESCRIPTION
## 작업 내용
대화 북마크를 열면 **해당 메시지 버블 위치로 스크롤** + 잠깐 강조(테라코타 링). 다른 기기에서도 동일 동작(서버에서 thread 로드).

- `chatStore.loadSession(id, { focusMessageId })`
  - `around` 파라미터로 타겟 주변 윈도우 요청(BE 지원 시)
  - 미지원 폴백: `cursor` 페이지네이션으로 최대 1000개까지 탐색
  - `created_at` 오름차순 정렬로 cursor 방향(과거/미래) 비의존
  - 타겟을 못 찾으면 focus 미설정 → 자동 하단 스크롤로 폴백
- `focusMessageId` 상태 + `clearFocusMessageId`, `chatsApi.messages` 에 `around` 추가
- `MessageBubble` 에 `data-message-id` 앵커
- `ChatMessages`: focus 스크롤 effect (`scrollIntoView({block:'center'})` + box-shadow 강조 + **ResizeObserver 로 lazy 카드 높이 변동 재정렬**), 하단 자동스크롤은 focus 진행 중 게이트
- `BookmarkPanel` 클릭 시 `item.messageId` 전달

## 참고 (BE)
- `around` 는 BE 가 아직 미지원이어도 안전(무시됨). 지원 시 즉시 정확 윈도우. 미지원이면 cursor 폴백이 커버.

## 검증
- [x] `tsc --noEmit` 통과
- [x] `eslint` 통과
- [x] `vite build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)