### PR TITLE
fix: 코스 폴리라인 + feat: 메시지 단위 공유

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -205,7 +205,7 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
                   <span>{isMessageBookmarked ? '저장됨' : '저장'}</span>
                 </button>
                 <FeedbackButton threadId={message.threadId} messageId={beMessageId} />
-                <ShareButton threadId={message.threadId} />
+                <ShareButton threadId={message.threadId} messageId={beMessageId} />
               </div>
             )}
           </div>

--- a/src/components/chat/ShareButton.tsx
+++ b/src/components/chat/ShareButton.tsx
@@ -1,14 +1,18 @@
 // 채팅 공유 버튼 — 클릭 시 share_token 발급 + URL 클립보드 복사.
-// 공유 후엔 "취소" 보조 액션 노출.
+// messageId 가 있으면 "이 답변만" / "대화 전체" 2가지 범위를 선택할 수 있다.
+//   - 이 답변만: BE message_range = { from: id, to: id } (단일 메시지 공유)
+//   - 대화 전체: message_range 없음(기존 동작)
 
 import { useState } from 'react';
-import { Share2, Check, X } from 'lucide-react';
+import { Share2, Check, X, MessageSquare, MessagesSquare } from 'lucide-react';
 import { chatsApi } from '@/lib/api';
 import { friendlyApiError } from '@/lib/auth-errors';
 import { toast } from '@/stores/toastStore';
 
 type Props = {
   threadId: string;
+  // 있으면 '이 답변만 공유' 옵션 노출(메시지 단위). 없으면 전체 공유만.
+  messageId?: number;
 };
 
 async function copyOrPrompt(url: string): Promise<boolean> {
@@ -30,19 +34,21 @@ async function copyOrPrompt(url: string): Promise<boolean> {
   return false;
 }
 
-export default function ShareButton({ threadId }: Props) {
+export default function ShareButton({ threadId, messageId }: Props) {
   const [copied, setCopied] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // 한 번이라도 공유했으면 "취소" 보조 액션 노출. 페이지 이탈 시 리셋(데모용 충분).
   const [wasShared, setWasShared] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
-  const onShare = async () => {
+  const doShare = async (range?: { from_message_id: number; to_message_id: number }) => {
     if (busy) return;
+    setMenuOpen(false);
     setBusy(true);
     setError(null);
     try {
-      const res = await chatsApi.share(threadId, {});
+      const res = await chatsApi.share(threadId, range ? { message_range: range } : {});
       // BE는 share_url을 "/shared/{token}"로 발급하지만 vite/vercel rewrite가 BE API로 잡아채감.
       // FE 라우트는 /s/{token}이므로 사용자에게 보여줄 URL은 그 형태로 치환.
       const fePath = res.share_url.replace(/^\/shared\//, '/s/');
@@ -52,7 +58,7 @@ export default function ShareButton({ threadId }: Props) {
       const ok = await copyOrPrompt(url);
       if (ok) {
         setCopied(true);
-        toast.success('공유 링크를 복사했어요');
+        toast.success(range ? '이 답변 공유 링크를 복사했어요' : '대화 공유 링크를 복사했어요');
         setTimeout(() => setCopied(false), 2200);
       } else {
         toast.info('클립보드 권한이 없어 prompt로 표시했어요');
@@ -65,6 +71,12 @@ export default function ShareButton({ threadId }: Props) {
     } finally {
       setBusy(false);
     }
+  };
+
+  const onShareClick = () => {
+    // messageId 있으면 범위 선택 메뉴, 없으면 전체 공유 즉시 실행.
+    if (messageId != null) setMenuOpen((v) => !v);
+    else void doShare();
   };
 
   const onRevoke = async () => {
@@ -85,18 +97,21 @@ export default function ShareButton({ threadId }: Props) {
   };
 
   return (
-    <div className="inline-flex items-center gap-1">
+    <div className="relative inline-flex items-center gap-1">
       <button
         type="button"
-        onClick={onShare}
+        onClick={onShareClick}
         disabled={busy}
-        title={error ?? '공유 링크 복사'}
-        aria-label="공유 링크 복사"
+        title={error ?? '공유'}
+        aria-label="공유"
+        aria-haspopup={messageId != null ? 'menu' : undefined}
+        aria-expanded={messageId != null ? menuOpen : undefined}
         className="inline-flex items-center gap-1.5 text-xs text-text-secondary hover:text-text-primary px-2 py-1 rounded hover:bg-bg-overlay transition-colors disabled:opacity-50"
       >
         {copied ? <Check size={14} /> : <Share2 size={14} />}
         <span>{copied ? '링크 복사됨' : '공유'}</span>
       </button>
+
       {wasShared && (
         <button
           type="button"
@@ -109,6 +124,37 @@ export default function ShareButton({ threadId }: Props) {
           <X size={13} />
           <span>취소</span>
         </button>
+      )}
+
+      {/* 범위 선택 메뉴 (messageId 있을 때만) */}
+      {menuOpen && messageId != null && (
+        <>
+          {/* 바깥 클릭 닫기 */}
+          <div className="fixed inset-0 z-40" aria-hidden="true" onClick={() => setMenuOpen(false)} />
+          <div
+            role="menu"
+            className="absolute bottom-full left-0 mb-1.5 z-50 w-44 rounded-xl border border-border bg-bg-surface shadow-md py-1 animate-fade-up"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => void doShare({ from_message_id: messageId, to_message_id: messageId })}
+              className="w-full flex items-center gap-2 px-3 py-2 text-[13px] text-text-primary hover:bg-bg-subtle transition-colors cursor-pointer"
+            >
+              <MessageSquare size={14} className="text-text-muted" aria-hidden="true" />
+              이 답변만 공유
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => void doShare()}
+              className="w-full flex items-center gap-2 px-3 py-2 text-[13px] text-text-primary hover:bg-bg-subtle transition-colors cursor-pointer"
+            >
+              <MessagesSquare size={14} className="text-text-muted" aria-hidden="true" />
+              대화 전체 공유
+            </button>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/components/map/GoogleMap.tsx
+++ b/src/components/map/GoogleMap.tsx
@@ -15,6 +15,9 @@ interface GoogleMapProps {
   itineraryMode?: boolean;
   congestionPoints?: CongestionPoint[];
   showHeatmap?: boolean;
+  // 코스 경로선 좌표(방문 순서). 주어지면 마커의 isBookmark 여부와 무관하게 이 순서로 그림.
+  // (코스 stop 이 북마크에도 포함될 때 폴리라인이 끊기던 문제 해결)
+  routePath?: { lat: number; lng: number }[];
 }
 
 const SEOUL_CENTER = { lat: 37.5665, lng: 126.978 };
@@ -180,6 +183,7 @@ export default function GoogleMap({
   itineraryMode = false,
   congestionPoints,
   showHeatmap = false,
+  routePath,
 }: GoogleMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<google.maps.Map | null>(null);
@@ -307,14 +311,16 @@ export default function GoogleMap({
       });
 
       // 코스(itineraryMode)일 때만 마커 간 경로선을 그림.
-      // 장소/행사 추천처럼 독립된 장소 목록에는 선을 연결하지 않음.
-      // 즐겨찾기(isBookmark)는 코스와 무관한 별도 핀이라 경로에서 제외 — 안 그러면
-      // 폴리라인이 즐겨찾기 위치까지 이어져 코스가 어지럽게 보임.
-      const routeMarkers = markers.filter((p) => !p.isBookmark);
-      if (itineraryMode && routeMarkers.length > 1) {
-        const path = routeMarkers.map((p) => ({ lat: p.lat, lng: p.lng }));
+      // 경로 좌표 우선순위:
+      //   1) routePath(코스 stop 방문 순서) — stop 이 북마크에도 포함돼도 끊기지 않음.
+      //   2) 폴백: 북마크 제외 마커 순서 — routePath 미제공 시.
+      // 장소/행사 추천처럼 독립된 장소 목록에는 선을 연결하지 않는다.
+      const routePts = routePath && routePath.length > 1
+        ? routePath
+        : markers.filter((p) => !p.isBookmark).map((p) => ({ lat: p.lat, lng: p.lng }));
+      if (itineraryMode && routePts.length > 1) {
         polylineRef.current = new google.maps.Polyline({
-          path,
+          path: routePts,
           strokeWeight: 7,
           strokeColor: '#1D4ED8',
           strokeOpacity: 0.9,
@@ -331,7 +337,7 @@ export default function GoogleMap({
     })().catch((err) => console.error('[GoogleMap] markers failed', err));
 
     return () => { cancelled = true; };
-  }, [mapReady, markers, itineraryMode, clearOverlays]);
+  }, [mapReady, markers, itineraryMode, clearOverlays, routePath]);
 
   // Selection style update — runs cheaply on selection change without recreating markers
   useEffect(() => {

--- a/src/components/map/MapPanel.tsx
+++ b/src/components/map/MapPanel.tsx
@@ -82,6 +82,14 @@ export default function MapPanel() {
 
   const hasContent = displayMarkers.length > 0 || is3D;
 
+  // 코스 경로선 좌표 — 코스 stop 방문 순서(store markers)를 그대로 사용.
+  // displayMarkers 는 북마크와 병합·정렬되므로, 코스 stop 이 북마크에 포함되면 isBookmark
+  // 처리되어 폴리라인에서 빠지는 문제가 있었음. 순수 코스 마커 순서를 직접 넘겨 해결.
+  const routePath = useMemo(
+    () => (isNavigating ? markers.map((p) => ({ lat: p.lat, lng: p.lng })) : undefined),
+    [isNavigating, markers],
+  );
+
   // Congestion overlay — 현재 화면에 표시된 마커들 중 BE congestion 정보가 있는 것만 사용.
   // BE PlaceBlock.congestion (area_proxy 단위 혼잡도)을 실제 데이터 소스로 활용.
   const congestionPoints = useMemo(
@@ -133,6 +141,7 @@ export default function MapPanel() {
                   selectedPlace={selectedPlace}
                   onSelectPlace={selectPlace}
                   itineraryMode={isNavigating}
+                  routePath={routePath}
                   congestionPoints={congestionPoints}
                   showHeatmap={heatmapOn}
                 />


### PR DESCRIPTION
## 1) 코스 폴리라인 버그 수정
코스 stop 이 북마크에도 포함되면 `displayMarkers` 에서 `isBookmark:true` 로 합쳐져, `GoogleMap` 의 폴리라인 필터(`!isBookmark`)에서 제외 → 선이 끊기거나 안 그려짐.
- `GoogleMap` 에 `routePath`(코스 stop 방문 순서 좌표) prop 추가 → 북마크 여부와 무관하게 이 순서로 폴리라인 렌더(폴백: 기존 마커 필터)
- `MapPanel` 이 store 의 코스 markers 순서로 `routePath` 전달(useMemo)

## 2) 메시지 단위 공유 (전체 + 블록 둘 다)
- `ShareButton` 에 `messageId` 추가 → 있으면 선택 메뉴: **이 답변만 공유**(BE `message_range = {from:id,to:id}`) / **대화 전체 공유**. 없으면 기존 전체 공유.
- `MessageBubble` 액션 행에서 `messageId` 전달
- BE 가 `message_range` 를 이미 지원, SharedPage 는 응답 messages 를 그대로 렌더하므로 단일 메시지 공유도 동작

## 검증
- [x] `tsc --noEmit` 통과
- [x] `eslint` 통과
- [x] `vite build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)