### PR TITLE
fix: 후보 없는 disambiguation 빈 화면 수정

### DIFF
--- a/src/components/chat/blocks/DisambiguationBlock.tsx
+++ b/src/components/chat/blocks/DisambiguationBlock.tsx
@@ -6,29 +6,38 @@ type Props = {
 };
 
 export default function DisambiguationBlock({ data, onSelect }: Props) {
-  if (!data.candidates?.length) return null;
+  const hasCandidates = !!data.candidates?.length;
+  // candidates 가 없어도 message(예: "어느 장소와 비교하시겠어요?")는 항상 렌더.
+  // BE 가 후보 없이 되묻는 disambiguation(REVIEW_COMPARE 등)을 빈 화면으로 떨구던 버그 수정.
+  if (!hasCandidates && !data.message) return null;
   return (
     <div className="rounded-xl border border-border bg-bg-surface p-3">
       <div className="text-[11px] font-medium uppercase tracking-wider text-text-muted mb-2">
-        어느 곳을 말씀하시는 건가요?
+        {hasCandidates ? '어느 곳을 말씀하시는 건가요?' : '추가 정보가 필요해요'}
       </div>
-      {data.message && <div className="text-sm text-text-secondary mb-3">{data.message}</div>}
-      <ul className="flex flex-col gap-1.5">
-        {data.candidates.map((c, i) => (
-          <li key={i}>
-            <button
-              type="button"
-              onClick={() => onSelect?.(i)}
-              className="w-full text-left px-3 py-2 rounded-lg border border-border hover:border-border-strong bg-bg-warm hover:bg-bg-surface transition-colors"
-            >
-              <div className="text-sm font-medium">{c.name}</div>
-              <div className="text-xs text-text-muted mt-0.5">
-                {[c.address, c.category].filter(Boolean).join(' · ')}
-              </div>
-            </button>
-          </li>
-        ))}
-      </ul>
+      {data.message && (
+        <div className={`text-sm text-text-secondary ${hasCandidates ? 'mb-3' : ''}`}>
+          {data.message}
+        </div>
+      )}
+      {hasCandidates && (
+        <ul className="flex flex-col gap-1.5">
+          {data.candidates!.map((c, i) => (
+            <li key={i}>
+              <button
+                type="button"
+                onClick={() => onSelect?.(i)}
+                className="w-full text-left px-3 py-2 rounded-lg border border-border hover:border-border-strong bg-bg-warm hover:bg-bg-surface transition-colors"
+              >
+                <div className="text-sm font-medium">{c.name}</div>
+                <div className="text-xs text-text-muted mt-0.5">
+                  {[c.address, c.category].filter(Boolean).join(' · ')}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 버그
"비교해줘"처럼 장소가 특정 안 된 REVIEW_COMPARE 등에서 BE 는 `candidates=[]` + `message`("어느 장소와 비교하시겠어요?")인 `disambiguation` 블록을 정확히 보내지만, FE `DisambiguationBlock` 이 `if (!data.candidates?.length) return null` 로 블록을 통째로 버려 **사용자에게 빈 화면**이 떴음.

## 수정
- `candidates` 유무와 무관하게 `message` 를 항상 렌더
- `candidates` 도 `message` 도 없을 때만 `null`
- 후보 없을 땐 헤더를 '추가 정보가 필요해요'로 표기(후보 선택 헤더와 구분)

## 검증
- [x] `tsc --noEmit` 통과
- [x] `eslint` 통과
- [x] `vite build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)