### PR TITLE
feat: EVENT 카드 클릭→새 탭 + 스테일 청크 흰 화면 방지

### DIFF
--- a/src/components/chat/blocks/EventsBlock.tsx
+++ b/src/components/chat/blocks/EventsBlock.tsx
@@ -1,53 +1,95 @@
 import type { EventsBlock as EventsBlockData } from '@/types/api';
-import { Calendar as CalendarIcon, MapPin } from 'lucide-react';
+import { Calendar as CalendarIcon, MapPin, ExternalLink } from 'lucide-react';
+
+// 출처(source) → 표시 라벨. 매핑 없으면 원문 그대로.
+const EVENT_SOURCE_LABEL: Record<string, string> = {
+  '서울시문화축제': '서울시 문화축제',
+  '서울시문화행사': '서울시 문화행사',
+  '서울시공공서비스예약': '공공서비스예약',
+  naver_blog: 'Naver 블로그',
+};
 
 export default function EventsBlock({ data }: { data: EventsBlockData }) {
   if (!data.items?.length) return null;
   return (
     <div className="flex flex-col gap-2">
-      {data.items.map((ev) => (
-        <a
-          key={ev.event_id}
-          href={ev.homepage_url ?? '#'}
-          target={ev.homepage_url ? '_blank' : undefined}
-          rel={ev.homepage_url ? 'noopener noreferrer' : undefined}
-          className="block rounded-xl border border-border bg-bg-surface p-3 hover:border-border-strong transition-colors"
-        >
+      {data.items.map((ev) => {
+        // 신규/구 필드명 모두 수용.
+        const href = ev.detail_url ?? ev.homepage_url;
+        const image = ev.poster_url ?? ev.image_url;
+        const startDate = ev.date_start ?? ev.start_date;
+        const endDate = ev.date_end ?? ev.end_date;
+        const sourceLabel = ev.source ? EVENT_SOURCE_LABEL[ev.source] ?? ev.source : null;
+        const hasLink = !!href;
+
+        const inner = (
           <div className="flex gap-3">
-            {ev.image_url && (
+            {image && (
               <img
-                src={ev.image_url}
+                src={image}
                 alt=""
                 className="w-16 h-16 rounded-lg object-cover flex-shrink-0 border border-border"
                 loading="lazy"
               />
             )}
             <div className="flex-1 min-w-0">
-              <div className="font-medium truncate">{ev.title}</div>
+              <div className="flex items-start gap-1.5">
+                <div className="font-medium truncate flex-1">{ev.title}</div>
+                {hasLink && (
+                  <ExternalLink size={13} className="text-text-muted shrink-0 mt-0.5" aria-hidden="true" />
+                )}
+              </div>
               <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-text-secondary">
-                {(ev.start_date || ev.end_date) && (
+                {(startDate || endDate) && (
                   <span className="inline-flex items-center gap-1">
-                    <CalendarIcon size={12} />
-                    {ev.start_date}
-                    {ev.end_date && ev.end_date !== ev.start_date ? ` ~ ${ev.end_date}` : ''}
+                    <CalendarIcon size={12} aria-hidden="true" />
+                    {startDate}
+                    {endDate && endDate !== startDate ? ` ~ ${endDate}` : ''}
                   </span>
                 )}
                 {(ev.place_name || ev.address) && (
                   <span className="inline-flex items-center gap-1 truncate">
-                    <MapPin size={12} />
+                    <MapPin size={12} aria-hidden="true" />
                     {ev.place_name ?? ev.address}
                   </span>
                 )}
+                {ev.price && <span className="inline-flex items-center">{ev.price}</span>}
               </div>
               {ev.description && (
                 <p className="text-[12px] text-text-secondary leading-[1.5] mt-1.5 line-clamp-2">
                   {ev.description}
                 </p>
               )}
+              {sourceLabel && (
+                <span className="inline-flex items-center mt-1.5 px-1.5 py-0.5 rounded-md text-[10.5px] font-medium bg-bg-subtle text-text-muted">
+                  {sourceLabel}
+                </span>
+              )}
             </div>
           </div>
-        </a>
-      ))}
+        );
+
+        const baseCls = 'block rounded-xl border border-border bg-bg-surface p-3 transition-[border-color,box-shadow] duration-200';
+
+        // detail_url 있으면 카드 전체가 새 탭 링크(키보드 접근성은 <a> 가 기본 제공).
+        // 없으면 일반 div — cursor default, 클릭 동작 없음.
+        return hasLink ? (
+          <a
+            key={ev.event_id}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${ev.title} 자세히 보기 (새 탭)`}
+            className={`${baseCls} hover:border-border-strong hover:shadow-sm cursor-pointer`}
+          >
+            {inner}
+          </a>
+        ) : (
+          <div key={ev.event_id} className={baseCls}>
+            {inner}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -93,6 +93,21 @@ function Bootstrap() {
   );
 }
 
+// 새 배포로 chunk 해시가 바뀐 뒤, 캐시된 페이지가 옛 chunk(.js)를 요청하면
+// SPA fallback(/(.*) → /index.html)이 HTML(text/html)을 200으로 반환 → MIME 에러로
+// dynamic import 실패 → 흰 화면. Vite 가 그 시점에 'vite:preloadError' 를 쏘므로
+// 세션당 1회 새로고침해 최신 index.html(새 해시)을 회수한다(무한 루프 방지).
+window.addEventListener('vite:preloadError', () => {
+  const KEY = 'chunk-preload-reloaded';
+  try {
+    if (sessionStorage.getItem(KEY)) return;
+    sessionStorage.setItem(KEY, '1');
+  } catch {
+    /* 스토리지 거부 환경 — 그래도 1회 reload 시도 */
+  }
+  window.location.reload();
+});
+
 startMockServiceWorker().finally(() => {
   createRoot(document.getElementById('root')!).render(
     <StrictMode>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -236,6 +236,14 @@ export type EventItem = {
   image_url?: string;
   homepage_url?: string;
   description?: string;
+  // EVENT 응답 신규 필드(PR #194/#200). detail_url=카드 클릭 대상, source=출처 라벨.
+  // 일부 신규 응답은 poster_url/date_start/date_end/price 명을 쓰므로 함께 수용(폴백).
+  detail_url?: string;
+  source?: string;
+  poster_url?: string;
+  date_start?: string;
+  date_end?: string;
+  price?: string;
 };
 
 export type EventsBlock = { type: 'events'; items: EventItem[]; total_count?: number };


### PR DESCRIPTION
EVENT 도메인 FE 협업 사항(PR #194/#200) 대응.

## 1) EVENT 카드 하이퍼링크
- `EventsBlock`: `detail_url`(폴백 `homepage_url`)이 있으면 **카드 전체가 새 탭 링크**(`<a target="_blank" rel="noopener noreferrer">`, hover 그림자/보더 피드백). 링크 없으면 일반 `div`(cursor default, 동작 X)
- 키보드 접근성: `<a>` 가 Enter 활성/Tab 포커스를 기본 제공(별도 role/tabindex 불필요)
- `source` 출처 배지 + `price` 표시. `poster_url`/`date_start`/`date_end` 신규 필드명 폴백 수용
- `EventItem` 타입에 `detail_url`/`source`/`poster_url`/`date_start`/`date_end`/`price` 추가

## 2) "추천 사유 / 인용"(references) EVENT 미노출
- 블록은 BE 주도라 EVENT 응답에서 `references` 미전송 → `BlockRenderer`가 존재 블록만 렌더하므로 **FE 자동 미노출**. PLACE 의 리뷰 snippet references 는 그대로(회귀 없음). → FE 변경 불필요(검증만)

## 3) 흰 화면(스테일 청크 회귀) 방지
- 새 배포로 chunk 해시가 바뀐 뒤 캐시 페이지가 옛 `.js` 요청 → `vercel.json` SPA fallback 이 `index.html`(text/html)을 200 반환 → MIME 에러로 흰 화면
- `main.tsx`에 `vite:preloadError` 핸들러 추가 → 세션당 1회 `location.reload()`로 최신 index 회수(무한 루프 방지)

## 검증
- [x] `tsc --noEmit` / `eslint` / `vite build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)