### PR TITLE
feat: 이미지리스 통일 마무리 + 업로드 취소 + 스테일청크 내성 + 잡일

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ videos/
 *.tsbuildinfo
 next-env.d.ts
 *.docx
+
+# local agent tooling (oh-my-claudecode / codex) — 로컬 설정, 커밋 제외
+.claude/
+.codex/

--- a/src/components/bookmark/BookmarkPanel.tsx
+++ b/src/components/bookmark/BookmarkPanel.tsx
@@ -158,12 +158,13 @@ function PlaceBookmarks({ places, onClose }: { places: Place[]; onClose?: () => 
                   onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
                 />
               ) : (
-                <span
-                  className="absolute inset-0 flex items-center justify-center text-[10px] font-semibold tracking-wider"
+                <cat.icon
+                  size={24}
+                  strokeWidth={1.8}
+                  className="absolute inset-1/2 -translate-x-1/2 -translate-y-1/2"
                   style={{ color: cat.color }}
-                >
-                  {cat.label.toUpperCase()}
-                </span>
+                  aria-hidden="true"
+                />
               )}
             </div>
             <div className="flex-1 min-w-0">

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -35,6 +35,8 @@ export default memo(function ChatInput({ onSend, disabled, showChips, loading, o
   const [uploading, setUploading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // 진행 중 이미지 업로드 취소용. 업로드 단계에서 중단 버튼 → abort.
+  const uploadAbortRef = useRef<AbortController | null>(null);
 
   // 미리보기 blob URL 정리 — 컴포넌트 언마운트 또는 이미지 교체 시 메모리 회수.
   useEffect(() => {
@@ -82,22 +84,34 @@ export default memo(function ChatInput({ onSend, disabled, showChips, loading, o
 
     let uploadedUrl: string | undefined;
     if (attachedImage) {
+      const ac = new AbortController();
+      uploadAbortRef.current = ac;
       setUploading(true);
       try {
-        const res = await uploadApi.image(attachedImage);
+        const res = await uploadApi.image(attachedImage, ac.signal);
         uploadedUrl = res.image_url;
       } catch (err) {
-        toast.error(friendlyApiError(err, '사진 업로드 실패'));
         setUploading(false);
+        uploadAbortRef.current = null;
+        // 사용자가 업로드를 취소(abort)한 경우 — 조용히 종료(텍스트·첨부 유지해 재시도 가능).
+        if (ac.signal.aborted) return;
+        toast.error(friendlyApiError(err, '사진 업로드 실패'));
         return;
       }
       setUploading(false);
+      uploadAbortRef.current = null;
       clearImage();
     }
 
     // text + imageUrl 분리해서 전달 — store 가 BE query 와 UI 표시용을 다르게 처리.
     onSend(trimmed, uploadedUrl);
     setText('');
+  };
+
+  // 중단 버튼: 업로드 중이면 업로드 abort, 그 외(SSE 응답 중)엔 onCancel(질문 취소).
+  const handleStop = () => {
+    if (uploading) uploadAbortRef.current?.abort();
+    else onCancel?.();
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -194,12 +208,12 @@ export default memo(function ChatInput({ onSend, disabled, showChips, loading, o
             )}
             aria-label="메시지 입력"
           />
-          {loading ? (
+          {loading || uploading ? (
             <button
               type="button"
-              onClick={onCancel}
+              onClick={handleStop}
               className="w-8 h-8 rounded-[10px] flex items-center justify-center bg-bg-subtle text-text-primary hover:bg-border transition-all duration-200 cursor-pointer shrink-0 active:scale-95"
-              aria-label="응답 생성 중단"
+              aria-label={uploading ? '사진 업로드 취소' : '응답 생성 중단'}
               title="중단"
             >
               <Square size={12} fill="currentColor" strokeWidth={0} />

--- a/src/components/map/ItineraryBottomSheet.tsx
+++ b/src/components/map/ItineraryBottomSheet.tsx
@@ -69,9 +69,7 @@ function ItineraryBottomSheetInner({ navigation, onClose, collapseOnSelect }: Pr
         {currentPlace.image ? (
           <img src={currentPlace.image} alt={currentPlace.name} className="w-full h-full object-cover" />
         ) : (
-          <span className="text-[20px] font-semibold" style={{ color: cat.color }}>
-            {cat.label[0]}
-          </span>
+          <cat.icon size={22} strokeWidth={1.8} style={{ color: cat.color }} aria-hidden="true" />
         )}
       </div>
 

--- a/src/components/map/PlaceOverlayCard.tsx
+++ b/src/components/map/PlaceOverlayCard.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export default memo(function PlaceOverlayCard({ place, onClose }: Props) {
   const cat = CATEGORY_CONFIG[place.category];
-  const initial = place.name.slice(0, 1);
+  const CatIcon = cat.icon;
 
   return (
     <div
@@ -28,7 +28,7 @@ export default memo(function PlaceOverlayCard({ place, onClose }: Props) {
           {place.image ? (
             <img src={place.image} alt={place.name} className="w-full h-full object-cover" />
           ) : (
-            initial
+            <CatIcon size={26} strokeWidth={1.8} style={{ color: cat.color }} aria-hidden="true" />
           )}
         </div>
 

--- a/src/components/map/PlaceOverlayItem.tsx
+++ b/src/components/map/PlaceOverlayItem.tsx
@@ -15,6 +15,7 @@ interface Props {
 
 export default memo(function PlaceOverlayItem({ place, isBookmark, isSelected, onSelect, onClose, registerRef }: Props) {
   const cat = CATEGORY_CONFIG[place.category];
+  const CatIcon = cat.icon;
   const ref = useRef<HTMLDivElement>(null);
   const toggleBookmark = useBookmarkStore((s) => s.toggle);
 
@@ -55,7 +56,7 @@ export default memo(function PlaceOverlayItem({ place, isBookmark, isSelected, o
             {place.image ? (
               <img src={place.image} alt={place.name} className="w-full h-full object-cover" />
             ) : (
-              place.name.slice(0, 1)
+              <CatIcon size={26} strokeWidth={1.8} style={{ color: cat.color }} aria-hidden="true" />
             )}
           </div>
           <button

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -31,9 +31,35 @@ export default class ErrorBoundary extends Component<Props, State> {
     this.setState({ hasError: false, error: null });
   };
 
+  handleReload = () => {
+    window.location.reload();
+  };
+
   render() {
     if (this.state.hasError) {
       if (this.props.fallback) return this.props.fallback;
+
+      // 새 배포로 chunk 해시가 바뀐 뒤 캐시 페이지가 옛 chunk 를 못 받는 경우(dynamic import
+      // 실패). 소프트 리셋으론 복구 안 되므로 전체 새로고침을 안내한다.
+      const msg = this.state.error?.message ?? '';
+      const isChunkError = /dynamically imported module|importing a module script failed|failed to fetch dynamically|chunkloaderror|loading chunk/i.test(msg);
+
+      if (isChunkError) {
+        return (
+          <div className="flex flex-col items-center justify-center p-8 text-center">
+            <div className="text-4xl mb-4">🔄</div>
+            <h3 className="text-sm font-semibold text-text-primary mb-1">
+              새 버전이 배포되었어요
+            </h3>
+            <p className="text-xs text-text-muted mb-4 max-w-xs">
+              페이지를 새로고침하면 최신 버전으로 이어집니다.
+            </p>
+            <Button variant="secondary" size="sm" onClick={this.handleReload}>
+              새로고침
+            </Button>
+          </div>
+        );
+      }
 
       return (
         <div className="flex flex-col items-center justify-center p-8 text-center">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -299,12 +299,13 @@ const UPLOAD_BASE: string =
   (import.meta.env.DEV ? '' : 'https://34.50.44.75.nip.io');
 
 export const uploadApi = {
-  image: (file: File) => {
+  image: (file: File, signal?: AbortSignal) => {
     const fd = new FormData();
     fd.append('file', file);
     return request<ImageUploadResponse>(`${UPLOAD_BASE}/api/v1/upload/image`, {
       method: 'POST',
       body: fd,
+      signal,
     });
   },
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,8 +9,6 @@ import './globals.css';
 import { useAuthStore } from '@/stores/authStore';
 import RequireAuth from '@/components/auth/RequireAuth';
 import Toaster from '@/components/ui/Toaster';
-// GSAP 플러그인(ScrollTrigger 등) 진입 시점에 1회 등록.
-import '@/lib/gsap-setup';
 
 // MSW — dev 환경에서 BE 미배포 상태 검수용.
 // VITE_DISABLE_MSW=true 로 끌 수 있음 (실서버 붙일 때).

--- a/vercel.json
+++ b/vercel.json
@@ -9,5 +9,15 @@
     { "source": "/health", "destination": "https://34.50.44.75.nip.io/health" },
     { "source": "/shared/:path*", "destination": "https://34.50.44.75.nip.io/shared/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    },
+    {
+      "source": "/index.html",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }]
+    }
   ]
 }


### PR DESCRIPTION
백로그 🅰️ FE 작업 일괄 처리.

## A-1 이미지리스 카드 통일(누락분)
빈 이미지 박스/글자 폴백이 남아있던 카드들의 폴백을 카테고리 아이콘으로 통일:
- `PlaceOverlayItem`, `PlaceOverlayCard` (지도 하단 오버레이)
- `ItineraryBottomSheet` (모바일 코스 시트)
- `BookmarkPanel` (북마크 카드)

## A-2 이미지 업로드 중 취소
- `uploadApi.image(file, signal)` — AbortSignal 지원
- `ChatInput`: 업로드용 `AbortController`. 업로드 단계에도 중단(■) 버튼 노출, abort 시 조용히 종료(텍스트·첨부 유지해 재시도 가능). (기존 SSE 취소와 동일 버튼)

## A-3 폰트/gsap
- Google·Pretendard 폰트 모두 **이미 `font-display: swap`** → 변경 불필요(확인)
- `main.tsx` 의 죽은 `gsap-setup` 사이드이펙트 import 제거(ScrollTrigger 제거 후 무의미). gsap 추가 지연은 번들 40%↓ 이후 고위험·저수익이라 제외

## A-4 스테일 청크 흰 화면 내성 강화
- `vercel.json` 캐시 헤더: `/assets/*` immutable, `index.html` no-cache → 새 배포 시 최신 해시 보장
- `ErrorBoundary`: dynamic import(chunk) 실패 감지 시 '새로고침' 안내 UI (소프트 리셋으론 복구 불가하므로)
- (앞서 머지된 `vite:preloadError` 자동 새로고침과 함께 3중 방어)

## A-5 잡일
- `.gitignore` 에 `.claude/` `.codex/` 추가(추적 파일 0개 확인)
- iOS 홈 아이콘: `apple-touch-icon` = 512×512 정사각 PNG 로 이미 충족

## 검증
- [x] `tsc --noEmit` / `eslint` / `vite build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)