### PR TITLE
feat: 브랜드명 LocalBiz → anyway 리브랜딩

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Seoul AI Guide</title>
+    <title>anyway</title>
     <meta name="description" content="서울의 모든 경험을 AI 에이전트와 함께" />
 
-    <!-- Favicon — LocalBiz 앱 아이콘(512x512 PNG). public/ 정적 자산이라 루트(/)에서 서빙됨. -->
-    <link rel="icon" type="image/png" href="/localfavicon.png" />
-    <link rel="apple-touch-icon" href="/localfavicon.png" />
+    <!-- Favicon — anyway 브랜드 마크(SVG). public/ 정적 자산이라 루트(/)에서 서빙됨. -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
     <meta name="theme-color" content="#F5F1EB" />
 
     <!-- Pretendard 는 self-host (npm 'pretendard') — main.tsx 에서 import.

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect width="24" height="24" rx="5" fill="#F5F1EB" />
+  <g transform="translate(0 3) scale(0.75) translate(4 4)">
+    <path d="M 12 12 L 12 0 A 12 12 0 0 1 22.392 18 Z" fill="#1F3A8B" />
+    <path d="M 12 12 L 22.392 18 A 12 12 0 0 1 1.608 18 Z" fill="#DC2127" />
+    <path d="M 12 12 L 1.608 18 A 12 12 0 0 1 12 0 Z" fill="#F4A12C" />
+    <circle cx="12" cy="12" r="2.4" fill="#FFFFFF" />
+  </g>
+</svg>

--- a/src/components/agent/CompactOrb.tsx
+++ b/src/components/agent/CompactOrb.tsx
@@ -18,7 +18,7 @@ export default memo(function CompactOrb({ isActive, onClick }: CompactOrbProps) 
       </div>
       <div className="flex flex-col">
         <span className="text-[13px] font-semibold text-text-primary leading-tight tracking-[-0.01em]">
-          LocalBiz
+          anyway
         </span>
         {isActive && (
           <span className="text-[10px] text-text-muted leading-tight">응답 중...</span>

--- a/src/components/auth/AuthLayout.tsx
+++ b/src/components/auth/AuthLayout.tsx
@@ -16,7 +16,7 @@ export default function AuthLayout({ title, subtitle, children, footer }: Props)
       <div className="w-full max-w-md">
         <div className="flex flex-col items-center justify-center mb-8 gap-2">
           <AgentOrb state="idle" size={72} interactive={false} />
-          <span className="font-display text-xl tracking-tight">LocalBiz</span>
+          <span className="font-display text-xl tracking-tight">anyway</span>
         </div>
 
         <div className="bg-bg-surface border-2 border-border-strong rounded-2xl p-8 shadow-[4px_4px_0_rgba(15,15,15,0.9)]">

--- a/src/components/calendar/CalendarPanel.tsx
+++ b/src/components/calendar/CalendarPanel.tsx
@@ -77,7 +77,7 @@ function EventCard({ event }: { event: CalendarEventItem }) {
           </h3>
           {isLocalBiz && (
             <span className="shrink-0 text-[10px] font-medium px-2 py-0.5 rounded-full bg-brand-subtle text-brand">
-              LocalBiz
+              anyway
             </span>
           )}
         </div>

--- a/src/components/share/SharedPage.tsx
+++ b/src/components/share/SharedPage.tsx
@@ -90,7 +90,7 @@ export default function SharedPage() {
             <path d="M 12 12 L 1.608 18 A 12 12 0 0 1 12 0 Z" fill="#F4A12C" />
             <circle cx="12" cy="12" r="2.4" fill="#FFFFFF" />
           </svg>
-          <span className="font-display text-base">LocalBiz</span>
+          <span className="font-display text-base">anyway</span>
         </Link>
 
         <div className="bg-bg-surface border-2 border-border-strong rounded-2xl p-6 shadow-[3px_3px_0_rgba(15,15,15,0.9)]">


### PR DESCRIPTION
## 작업 내용
- 화면에 노출되는 브랜드 텍스트 `LocalBiz` → `anyway` 변경
  - `AuthLayout` (로그인 로고), `SharedPage` (공유 헤더), `CompactOrb` (상단 브랜드명), `CalendarPanel` (출처 뱃지)
- `index.html` title `Seoul AI Guide` → `anyway`
- favicon을 anyway 브랜드 마크(SVG)로 교체 (`public/favicon.svg`), `localfavicon.png` 참조 제거
- 백엔드 데이터 계약값 `'localbiz'`(이벤트 source)는 그대로 유지

## 체크리스트
- [x] tsc + build 통과
- [x] lint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)