### PR TITLE
feat: 채팅 추천 카드 레트로 포스터 스타일 업그레이드

### DIFF
--- a/src/components/chat/ItineraryCard.tsx
+++ b/src/components/chat/ItineraryCard.tsx
@@ -51,7 +51,7 @@ export default function ItineraryCard({ itinerary, hideActions = false }: { itin
   }, { scope: stopsRef });
 
   return (
-    <div className="bg-bg-surface border border-border rounded-2xl overflow-hidden">
+    <div className="card-poster-static rounded-2xl overflow-hidden">
       {/* Header */}
       <div className="px-4 py-3 border-b border-border bg-bg-subtle/50 flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
@@ -163,10 +163,10 @@ export default function ItineraryCard({ itinerary, hideActions = false }: { itin
 
       {/* Actions — shared 페이지 같은 read-only 컨텍스트에선 숨김 */}
       {!hideActions && (
-        <div className="flex border-t border-border">
+        <div className="flex border-t-2 border-border-strong">
           <button
             onClick={() => startNavigation(itinerary)}
-            className="flex-1 py-2.5 text-[12px] font-medium text-brand hover:bg-brand-subtle transition-colors cursor-pointer border-r border-border"
+            className="flex-1 py-2.5 text-[12px] font-semibold text-white bg-brand hover:bg-brand-hover active:bg-brand-hover transition-colors cursor-pointer border-r-2 border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/70"
           >
             경로 보기
           </button>
@@ -176,7 +176,7 @@ export default function ItineraryCard({ itinerary, hideActions = false }: { itin
               void sendMessage(`"${itinerary.title}" 코스를 내 캘린더에 추가해줘`);
             }}
             disabled={isLoading}
-            className="flex-1 py-2.5 text-[12px] font-medium text-brand hover:bg-brand-subtle transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex-1 py-2.5 text-[12px] font-medium text-brand hover:bg-brand-subtle active:bg-brand-subtle transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand"
           >
             일정 추가
           </button>

--- a/src/components/chat/PlaceCarousel.tsx
+++ b/src/components/chat/PlaceCarousel.tsx
@@ -36,7 +36,7 @@ function PlaceCardTile({ place, variant, onSelect }: PlaceCardTileProps) {
     <div
       onClick={() => onSelect(place)}
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect(place); }}
-      className={`${widthClass} snap-start bg-bg-surface border border-border rounded-2xl overflow-hidden transition-[border-color,box-shadow] duration-200 active:scale-[0.97] cursor-pointer text-left`}
+      className={`${widthClass} card-poster snap-start rounded-2xl overflow-hidden cursor-pointer text-left`}
       role="button"
       tabIndex={0}
       aria-label={`${place.name} - ${cat.label}`}
@@ -130,7 +130,7 @@ export default function PlaceCarousel({ places }: PlaceCarouselProps) {
     <div className="mt-3 -mx-5">
       <div
         ref={scrollRef}
-        className="flex gap-3 overflow-x-auto px-5 pb-2 snap-x snap-mandatory"
+        className="flex gap-3 overflow-x-auto px-5 py-2 snap-x snap-mandatory"
         style={SCROLL_STYLE}
       >
         {places.map((place) => (

--- a/src/components/chat/blocks/EventsBlock.tsx
+++ b/src/components/chat/blocks/EventsBlock.tsx
@@ -69,10 +69,8 @@ export default function EventsBlock({ data }: { data: EventsBlockData }) {
           </div>
         );
 
-        const baseCls = 'block rounded-xl border border-border bg-bg-surface p-3 transition-[border-color,box-shadow] duration-200';
-
-        // detail_url 있으면 카드 전체가 새 탭 링크(키보드 접근성은 <a> 가 기본 제공).
-        // 없으면 일반 div — cursor default, 클릭 동작 없음.
+        // detail_url 있으면 카드 전체가 새 탭 링크(키보드 접근성은 <a> 가 기본 제공) → 포스터 리프트.
+        // 없으면 정적 포스터 — cursor default, 클릭 동작 없음.
         return hasLink ? (
           <a
             key={ev.event_id}
@@ -80,12 +78,12 @@ export default function EventsBlock({ data }: { data: EventsBlockData }) {
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`${ev.title} 자세히 보기 (새 탭)`}
-            className={`${baseCls} hover:border-border-strong hover:shadow-sm cursor-pointer`}
+            className="block rounded-xl p-3 card-poster cursor-pointer"
           >
             {inner}
           </a>
         ) : (
-          <div key={ev.event_id} className={baseCls}>
+          <div key={ev.event_id} className="block rounded-xl p-3 card-poster-static">
             {inner}
           </div>
         );

--- a/src/globals.css
+++ b/src/globals.css
@@ -234,3 +234,43 @@
   background-size: 200% 100%;
   animation: shimmer 1.8s infinite ease-in-out;
 }
+
+/* === Poster cards — 레트로 포스터 카드 인터랙션 ===
+   굵은 흑선 + chunky offset drop. 호버 시 카드가 좌상단으로 떠오르며 그림자가 깊어지고,
+   누르면 우하단으로 내려앉아 "도장처럼 눌리는" 촉각감. auth/share 페이지 정체성과 통일. */
+.card-poster {
+  border: 2px solid var(--color-border-strong);
+  background: var(--color-bg-surface);
+  box-shadow: 2px 2px 0 rgba(15, 15, 15, 0.9);
+  transition: box-shadow 0.18s cubic-bezier(0.32, 0.72, 0, 1),
+              transform 0.18s cubic-bezier(0.32, 0.72, 0, 1);
+}
+.card-poster:hover {
+  box-shadow: 4px 4px 0 rgba(15, 15, 15, 0.9);
+  transform: translate(-2px, -2px);
+}
+.card-poster:active {
+  box-shadow: 1px 1px 0 rgba(15, 15, 15, 0.9);
+  transform: translate(1px, 1px);
+}
+.card-poster:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 3px;
+}
+
+/* 비인터랙티브 컨테이너용 — 굵은 흑선 + 정적 오프셋 그림자(호버 리프트 없음). */
+.card-poster-static {
+  border: 2px solid var(--color-border-strong);
+  background: var(--color-bg-surface);
+  box-shadow: 3px 3px 0 rgba(15, 15, 15, 0.9);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-poster {
+    transition: box-shadow 0.18s ease;
+  }
+  .card-poster:hover,
+  .card-poster:active {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## 작업 내용
채팅 추천 카드(장소·이벤트·코스)를 auth/share 페이지가 이미 쓰는 **레트로 포스터 정체성**(굵은 흑선 `border-2 border-border-strong` + chunky offset 그림자)으로 통일. 기존엔 얇은 `border border-border` + `shadow-sm`이라 정체성이 따로 놀았음.

### 변경
- `globals.css`: `.card-poster`(호버 시 좌상단으로 떠오르며 그림자 깊어짐, 누르면 우하단 프레스, `focus-visible` 링, `prefers-reduced-motion` 대응) + `.card-poster-static`(정적 컨테이너용) 유틸 추가
- `PlaceCarousel`: 장소 카드 타일 → `.card-poster` (이전엔 호버 피드백 없었음). 스크롤 컨테이너 `py-2`로 리프트/focus 링 클리핑 방지
- `EventsBlock`: 링크 있는 카드 → 인터랙티브 포스터, 없는 카드 → 정적 포스터
- `ItineraryCard`: 외곽 → 정적 포스터, 푸터 '경로 보기'를 brand fill 1차 액션으로 승격 + 두 버튼 focus 링

### 리뷰
code-reviewer 패스 → **SHIP** (BLOCKER/HIGH 0). 지적된 캐러셀 상단 클리핑(MEDIUM) 반영 완료. 토큰 전부 존재 확인, white-on-brand 대비 4.90:1 (AA 통과), reduced-motion/focus 처리 확인.

## 후속(out of scope)
- `DisambiguationBlock`은 아직 얇은 보더 — 일관성 위해 다음에 변환 가능

## 체크리스트
- [x] tsc + build 통과
- [x] lint 통과
- [x] 별도 리뷰 패스 (자가승인 금지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)