### PR TITLE
feat: 트렌디 그라데이션 정체성 전 페이지 롤아웃

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,18 @@
     <noscript>
       <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Archivo:wght@400;500;600;700;900&family=Inter:wght@400;500;600;700&display=swap" />
     </noscript>
+
+    <!-- Clash Display (Fontshare) — 트렌디 라운드 헤비 그로테스크. 현재 로그인 파일럿 헤드라인에만 사용. -->
+    <link rel="preconnect" href="https://api.fontshare.com" crossorigin />
+    <link
+      rel="preload"
+      as="style"
+      href="https://api.fontshare.com/v2/css?f[]=clash-display@400,500,600,700&display=swap"
+      onload="this.onload=null;this.rel='stylesheet'"
+    />
+    <noscript>
+      <link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=clash-display@400,500,600,700&display=swap" />
+    </noscript>
   </head>
   <body class="h-full overflow-hidden">
     <div id="root" class="h-full"></div>

--- a/src/components/agent/AgentOrb.tsx
+++ b/src/components/agent/AgentOrb.tsx
@@ -10,6 +10,8 @@ interface AgentOrbProps {
   size?: number;
   /** size가 작을 때 호버 인터랙션/포인터를 끔. 헤더 같은 임베디드 용도. */
   interactive?: boolean;
+  /** 굵고 진한 선 + 잉크 아웃라인 — 밝은 그라데이션 배경에서도 또렷하게(로그인 파일럿). */
+  bold?: boolean;
 }
 
 const BRAND_PALETTE: { r: number; g: number; b: number }[] = [
@@ -28,7 +30,7 @@ const FULL_RADIUS_RATIO = 0.22;
 const COMPACT_RADIUS_RATIO = 0.42;
 const COMPACT_THRESHOLD = 80;
 
-export default function AgentOrb({ state = 'idle', size = 400, interactive = true }: AgentOrbProps) {
+export default function AgentOrb({ state = 'idle', size = 400, interactive = true, bold = false }: AgentOrbProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>(0);
   const timeRef = useRef(0);
@@ -84,8 +86,13 @@ export default function AgentOrb({ state = 'idle', size = 400, interactive = tru
       }
 
       // 2) 와이어프레임 — wave 진폭도 baseRadius 비례.
-      ctx.lineWidth = Math.max(0.8, baseRadius * 0.015);
+      ctx.lineWidth = Math.max(0.8, baseRadius * (bold ? 0.032 : 0.015));
       ctx.lineCap = 'round';
+      // bold: 밝은 배경 대비용 잉크 아웃라인. 와이어프레임에만 적용하고 입자/글로우 전에 해제.
+      if (bold) {
+        ctx.shadowColor = 'rgba(15, 15, 15, 0.5)';
+        ctx.shadowBlur = Math.max(1.5, baseRadius * 0.05);
+      }
 
       const rotationX = time * config.speed * 0.3;
       const rotationY = time * config.speed * 0.5;
@@ -136,7 +143,7 @@ export default function AgentOrb({ state = 'idle', size = 400, interactive = tru
           if (j === 0) ctx.moveTo(screenX, screenY);
           else ctx.lineTo(screenX, screenY);
 
-          ctx.strokeStyle = `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha * 0.6})`;
+          ctx.strokeStyle = `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha * (bold ? 1 : 0.6)})`;
         }
         ctx.stroke();
       }
@@ -186,9 +193,15 @@ export default function AgentOrb({ state = 'idle', size = 400, interactive = tru
           if (j === 0) ctx.moveTo(screenX, screenY);
           else ctx.lineTo(screenX, screenY);
 
-          ctx.strokeStyle = `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha * 0.5})`;
+          ctx.strokeStyle = `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha * (bold ? 0.9 : 0.5)})`;
         }
         ctx.stroke();
+      }
+
+      // 와이어프레임용 잉크 아웃라인 해제 — 입자/글로우는 그림자 없이.
+      if (bold) {
+        ctx.shadowBlur = 0;
+        ctx.shadowColor = 'transparent';
       }
 
       // 3) 입자 — 작은 사이즈에선 비활성.
@@ -255,7 +268,7 @@ export default function AgentOrb({ state = 'idle', size = 400, interactive = tru
         }
       }
     },
-    [state, isHovered, interactive, size],
+    [state, isHovered, interactive, size, bold],
   );
 
   useEffect(() => {

--- a/src/components/auth/AuthLayout.tsx
+++ b/src/components/auth/AuthLayout.tsx
@@ -1,4 +1,5 @@
-// 88 올림픽 톤의 단순한 인증 폼 셸 (Login/Signup 공용).
+// 트렌디 그라데이션 파일럿 — 웜 그라데이션 배경 + 비비드 블롭 + 라운드 헤비 그로테스크.
+// 레트로 정체성(굵은 흑선 카드 + chunky 오프셋 그림자)은 유지하며 색/폰트만 융합.
 
 import type { ReactNode } from 'react';
 import AgentOrb from '@/components/agent/AgentOrb';
@@ -12,20 +13,42 @@ type Props = {
 
 export default function AuthLayout({ title, subtitle, children, footer }: Props) {
   return (
-    <div className="min-h-screen w-full flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md">
-        <div className="flex flex-col items-center justify-center mb-8 gap-2">
-          <AgentOrb state="idle" size={72} interactive={false} />
-          <span className="font-display text-xl tracking-tight">Anyway</span>
+    <div className="relative min-h-screen w-full flex items-center justify-center px-4 py-12 bg-warm-gradient overflow-hidden">
+      {/* 비비드 그라데이션 블롭 — 레퍼런스의 손 일러스트 자리를 블러 오브로 대체, 깊이감만 */}
+      <div
+        aria-hidden="true"
+        className="bg-vivid-gradient pointer-events-none absolute -left-24 top-1/3 h-72 w-72 rounded-full opacity-60 blur-3xl"
+      />
+      <div
+        aria-hidden="true"
+        className="bg-vivid-gradient pointer-events-none absolute -right-20 bottom-10 h-64 w-64 rounded-full opacity-40 blur-3xl"
+      />
+
+      <div className="relative w-full max-w-md">
+        {/* 로고 + 민트 스티커 */}
+        <div className="flex flex-col items-center justify-center mb-8 gap-3">
+          {/* 흰 받침 + 굵은 선 orb. 레트로 흑선+chunky 융합 */}
+          <div className="flex items-center justify-center rounded-full bg-bg-surface border-2 border-border-strong p-4 shadow-[4px_4px_0_rgba(15,15,15,0.9)]">
+            <AgentOrb state="idle" size={78} interactive={false} bold />
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="font-display-round text-3xl text-text-primary">Anyway</span>
+            <span
+              className="rotate-[-6deg] rounded-full border-2 border-border-strong bg-accent-mint px-2.5 py-0.5 text-[11px] font-bold text-accent-mint-ink shadow-[2px_2px_0_rgba(15,15,15,0.9)]"
+            >
+              SEOUL
+            </span>
+          </div>
         </div>
 
+        {/* 카드 — 레트로 융합 유지(순백 + 굵은 흑선 + chunky 그림자) */}
         <div className="bg-bg-surface border-2 border-border-strong rounded-2xl p-8 shadow-[4px_4px_0_rgba(15,15,15,0.9)]">
-          <h1 className="font-display text-2xl mb-2">{title}</h1>
+          <h1 className="font-display-round text-[28px] leading-tight mb-2 text-text-primary">{title}</h1>
           {subtitle && <p className="text-sm text-text-secondary mb-6">{subtitle}</p>}
           {children}
         </div>
 
-        {footer && <div className="mt-6 text-center text-sm text-text-secondary">{footer}</div>}
+        {footer && <div className="mt-6 text-center text-sm text-text-primary/80">{footer}</div>}
       </div>
     </div>
   );

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -1,9 +1,9 @@
 import { useState, type FormEvent } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
 import { useAuthStore } from '@/stores/authStore';
 import { friendlyAuthError } from '@/lib/auth-errors';
 import AuthLayout from './AuthLayout';
-import Button from '@/components/ui/Button';
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -58,7 +58,7 @@ export default function LoginPage() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="px-3 py-2 rounded-lg border border-border focus:border-brand outline-none transition-colors"
+            className="px-3.5 py-2.5 rounded-xl border-2 border-border bg-bg-surface focus:border-brand outline-none transition-colors"
             placeholder="you@example.com"
           />
         </label>
@@ -71,7 +71,7 @@ export default function LoginPage() {
             minLength={8}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="px-3 py-2 rounded-lg border border-border focus:border-brand outline-none transition-colors"
+            className="px-3.5 py-2.5 rounded-xl border-2 border-border bg-bg-surface focus:border-brand outline-none transition-colors"
             placeholder="8자 이상"
           />
         </label>
@@ -80,9 +80,16 @@ export default function LoginPage() {
             {error}
           </div>
         )}
-        <Button type="submit" disabled={submitting} size="lg">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="group mt-1 flex w-full items-center justify-center gap-2 rounded-full border-2 border-border-strong bg-brand py-3 text-[15px] font-semibold text-white shadow-[3px_3px_0_rgba(15,15,15,0.9)] transition-[transform,box-shadow] duration-150 hover:shadow-[5px_5px_0_rgba(15,15,15,0.9)] active:shadow-[1px_1px_0_rgba(15,15,15,0.9)] motion-safe:hover:-translate-x-0.5 motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-x-0.5 motion-safe:active:translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-[3px_3px_0_rgba(15,15,15,0.9)] disabled:translate-x-0 disabled:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-strong focus-visible:ring-offset-2"
+        >
           {submitting ? '로그인 중...' : '로그인'}
-        </Button>
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-brand">
+            <ArrowRight size={14} strokeWidth={2.6} aria-hidden="true" />
+          </span>
+        </button>
       </form>
     </AuthLayout>
   );

--- a/src/components/auth/SignupPage.tsx
+++ b/src/components/auth/SignupPage.tsx
@@ -1,9 +1,9 @@
 import { useState, type FormEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
 import { useAuthStore } from '@/stores/authStore';
 import { friendlyAuthError } from '@/lib/auth-errors';
 import AuthLayout from './AuthLayout';
-import Button from '@/components/ui/Button';
 
 export default function SignupPage() {
   const navigate = useNavigate();
@@ -84,9 +84,16 @@ export default function SignupPage() {
             {error}
           </div>
         )}
-        <Button type="submit" disabled={submitting} size="lg">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="group mt-1 flex w-full items-center justify-center gap-2 rounded-full border-2 border-border-strong bg-brand py-3 text-[15px] font-semibold text-white shadow-[3px_3px_0_rgba(15,15,15,0.9)] transition-[transform,box-shadow] duration-150 hover:shadow-[5px_5px_0_rgba(15,15,15,0.9)] active:shadow-[1px_1px_0_rgba(15,15,15,0.9)] motion-safe:hover:-translate-x-0.5 motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-x-0.5 motion-safe:active:translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-[3px_3px_0_rgba(15,15,15,0.9)] disabled:translate-x-0 disabled:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-strong focus-visible:ring-offset-2"
+        >
           {submitting ? '가입 중...' : '회원가입'}
-        </Button>
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-brand">
+            <ArrowRight size={14} strokeWidth={2.6} aria-hidden="true" />
+          </span>
+        </button>
       </form>
     </AuthLayout>
   );

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -84,11 +84,23 @@ export default memo(function ChatMessages() {
     <div ref={scrollRef} data-chat-scroller className="flex-1 overflow-y-auto overscroll-contain">
       {hasOnlyWelcome && (
         <div className="flex flex-col items-center justify-center pt-14 pb-10 px-8 animate-fade-up">
-          <div className="mb-7">
-            <AgentOrb state={isLoading ? 'thinking' : 'idle'} size={220} />
+          <div className="relative mb-7">
+            {/* 민트 블러 블롭 — 오브 뒤 깊이감 */}
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 m-auto h-40 w-40 rounded-full bg-accent-mint opacity-30 blur-2xl"
+            />
+            <AgentOrb state={isLoading ? 'thinking' : 'idle'} size={220} bold />
+            {/* 민트 스티커 뱃지 */}
+            <span
+              aria-hidden="true"
+              className="absolute -bottom-2 -right-2 rotate-[8deg] rounded-full border-2 border-border-strong bg-accent-mint px-2.5 py-0.5 text-[10px] font-bold text-accent-mint-ink shadow-[2px_2px_0_rgba(15,15,15,0.9)]"
+            >
+              SEOUL AI
+            </span>
           </div>
           <h2
-            className="text-[34px] leading-[1.05] text-text-primary mb-3 text-center"
+            className="text-[34px] leading-[1.05] text-text-primary mb-3 text-center font-bold"
             style={{ fontFamily: 'var(--font-display)', letterSpacing: '-0.025em', wordBreak: 'keep-all' }}
           >
             서울을<br />탐색해보세요

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -69,18 +69,18 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="h-full w-full overflow-y-auto px-4 py-10">
+    <div className="h-full w-full overflow-y-auto bg-warm-gradient px-4 py-10">
       <div className="max-w-xl mx-auto">
         <button
           onClick={() => navigate(-1)}
-          className="inline-flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary mb-6"
+          className="inline-flex items-center gap-1.5 text-sm text-text-primary hover:text-text-primary mb-6"
         >
           <ArrowLeft size={16} /> 뒤로
         </button>
-        <h1 className="font-display text-3xl mb-1">설정</h1>
-        <p className="text-sm text-text-secondary mb-8">{user?.email}</p>
+        <h1 className="font-display-round text-3xl mb-1 text-text-primary">설정</h1>
+        <p className="text-sm text-text-primary/70 mb-8">{user?.email}</p>
 
-        <section className="bg-bg-surface border-2 border-border-strong rounded-2xl p-6 shadow-[2px_2px_0_rgba(15,15,15,0.9)] mb-6">
+        <section className="card-poster-static rounded-2xl p-6 mb-6">
           <h2 className="font-display text-lg mb-4">프로필</h2>
           <form onSubmit={onSaveNickname} className="flex flex-col gap-4">
             <label className="flex flex-col gap-1.5 text-sm">
@@ -90,7 +90,7 @@ export default function SettingsPage() {
                 maxLength={100}
                 value={nickname}
                 onChange={(e) => setNickname(e.target.value)}
-                className="px-3 py-2 rounded-lg border border-border focus:border-brand outline-none transition-colors"
+                className="px-3.5 py-2.5 rounded-xl border-2 border-border bg-bg-surface focus:border-brand outline-none transition-colors"
               />
             </label>
             {nicknameMsg && <div className="text-sm text-text-secondary">{nicknameMsg}</div>}
@@ -100,7 +100,7 @@ export default function SettingsPage() {
           </form>
         </section>
 
-        <section className="bg-bg-surface border-2 border-border-strong rounded-2xl p-6 shadow-[2px_2px_0_rgba(15,15,15,0.9)] mb-6">
+        <section className="card-poster-static rounded-2xl p-6 mb-6">
           <h2 className="font-display text-lg mb-4">비밀번호 변경</h2>
           <form onSubmit={onChangePassword} className="flex flex-col gap-4">
             <label className="flex flex-col gap-1.5 text-sm">
@@ -111,7 +111,7 @@ export default function SettingsPage() {
                 required
                 value={oldPw}
                 onChange={(e) => setOldPw(e.target.value)}
-                className="px-3 py-2 rounded-lg border border-border focus:border-brand outline-none transition-colors"
+                className="px-3.5 py-2.5 rounded-xl border-2 border-border bg-bg-surface focus:border-brand outline-none transition-colors"
               />
             </label>
             <label className="flex flex-col gap-1.5 text-sm">
@@ -124,7 +124,7 @@ export default function SettingsPage() {
                 maxLength={128}
                 value={newPw}
                 onChange={(e) => setNewPw(e.target.value)}
-                className="px-3 py-2 rounded-lg border border-border focus:border-brand outline-none transition-colors"
+                className="px-3.5 py-2.5 rounded-xl border-2 border-border bg-bg-surface focus:border-brand outline-none transition-colors"
               />
             </label>
             {pwMsg && <div className="text-sm text-text-secondary">{pwMsg}</div>}
@@ -134,7 +134,7 @@ export default function SettingsPage() {
           </form>
         </section>
 
-        <section className="bg-bg-surface border-2 border-border-strong rounded-2xl p-6 shadow-[2px_2px_0_rgba(15,15,15,0.9)] mb-6">
+        <section className="card-poster-static rounded-2xl p-6 mb-6">
           <h2 className="font-display text-lg mb-2">Google Calendar 연동</h2>
           <p className="text-sm text-text-secondary mb-4">
             추천 일정을 본인 Google Calendar에 자동 등록합니다.
@@ -145,7 +145,7 @@ export default function SettingsPage() {
           </Button>
         </section>
 
-        <section className="bg-bg-surface border border-border rounded-2xl p-6">
+        <section className="card-poster-static rounded-2xl p-6">
           <h2 className="font-display text-lg mb-3">로그아웃</h2>
           <Button
             variant="danger"

--- a/src/components/share/CalendarConnected.tsx
+++ b/src/components/share/CalendarConnected.tsx
@@ -5,7 +5,6 @@
 
 import { Link, useSearchParams } from 'react-router-dom';
 import { CheckCircle2, XCircle, ArrowRight } from 'lucide-react';
-import Button from '@/components/ui/Button';
 
 export default function CalendarConnected() {
   const [params] = useSearchParams();
@@ -13,13 +12,13 @@ export default function CalendarConnected() {
   const success = !error;
 
   return (
-    <div className="min-h-screen w-full flex items-center justify-center px-4 py-12">
+    <div className="min-h-screen w-full flex items-center justify-center px-4 py-12 bg-warm-gradient">
       <div className="w-full max-w-md">
         <div className="bg-bg-surface border-2 border-border-strong rounded-2xl p-8 shadow-[4px_4px_0_rgba(15,15,15,0.9)] text-center">
           {success ? (
             <>
               <CheckCircle2 size={48} strokeWidth={1.5} className="text-[#6B8E5A] mx-auto mb-4" />
-              <h1 className="font-display text-2xl mb-2">연동 완료</h1>
+              <h1 className="font-display-round text-2xl mb-2">연동 완료</h1>
               <p className="text-sm text-text-secondary mb-6">
                 Google Calendar 연결이 완료되었어요.
                 이제 추천 일정을 본인 캘린더에 자동 등록할 수 있어요.
@@ -28,7 +27,7 @@ export default function CalendarConnected() {
           ) : (
             <>
               <XCircle size={48} strokeWidth={1.5} className="text-brand mx-auto mb-4" />
-              <h1 className="font-display text-2xl mb-2">연동 실패</h1>
+              <h1 className="font-display-round text-2xl mb-2">연동 실패</h1>
               <p className="text-sm text-text-secondary mb-6">
                 {error === 'access_denied'
                   ? '권한 요청을 취소했어요. 다시 시도하려면 설정에서 연동해 주세요.'
@@ -36,12 +35,14 @@ export default function CalendarConnected() {
               </p>
             </>
           )}
-          <Link to="/">
-            <Button>
-              <span className="inline-flex items-center gap-1.5">
-                메인으로 <ArrowRight size={14} />
-              </span>
-            </Button>
+          <Link
+            to="/"
+            className="group inline-flex items-center justify-center gap-2 rounded-full border-2 border-border-strong bg-brand px-6 py-2.5 text-[15px] font-semibold text-white shadow-[3px_3px_0_rgba(15,15,15,0.9)] transition-[transform,box-shadow] duration-150 hover:shadow-[5px_5px_0_rgba(15,15,15,0.9)] active:shadow-[1px_1px_0_rgba(15,15,15,0.9)] motion-safe:hover:-translate-x-0.5 motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-x-0.5 motion-safe:active:translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-strong focus-visible:ring-offset-2"
+          >
+            메인으로
+            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-brand">
+              <ArrowRight size={14} strokeWidth={2.6} aria-hidden="true" />
+            </span>
           </Link>
         </div>
       </div>

--- a/src/components/share/SharedPage.tsx
+++ b/src/components/share/SharedPage.tsx
@@ -81,7 +81,7 @@ export default function SharedPage() {
   }, [token]);
 
   return (
-    <div className="h-full w-full overflow-y-auto px-4 py-10">
+    <div className="h-full w-full overflow-y-auto bg-warm-gradient px-4 py-10">
       <div className="max-w-2xl mx-auto">
         <Link to="/" className="inline-flex items-center gap-2 mb-6">
           <svg width="28" height="28" viewBox="0 0 24 24" aria-hidden="true">
@@ -90,12 +90,12 @@ export default function SharedPage() {
             <path d="M 12 12 L 1.608 18 A 12 12 0 0 1 12 0 Z" fill="#F4A12C" />
             <circle cx="12" cy="12" r="2.4" fill="#FFFFFF" />
           </svg>
-          <span className="font-display text-base">Anyway</span>
+          <span className="font-display text-base text-text-primary">Anyway</span>
         </Link>
 
         <div className="bg-bg-surface border-2 border-border-strong rounded-2xl p-6 shadow-[3px_3px_0_rgba(15,15,15,0.9)]">
           <div className="flex items-center justify-between mb-6">
-            <h1 className="font-display text-2xl">{data?.thread_title ?? '공유된 대화'}</h1>
+            <h1 className="font-display-round text-2xl">{data?.thread_title ?? '공유된 대화'}</h1>
             <span className="text-xs text-text-muted uppercase tracking-wider">read-only</span>
           </div>
 
@@ -116,7 +116,7 @@ export default function SharedPage() {
         </div>
 
         <div className="mt-6 text-center">
-          <Link to="/" className="text-sm text-text-secondary hover:text-text-primary">
+          <Link to="/" className="text-sm text-text-primary hover:text-text-primary">
             나만의 서울 만들기 →
           </Link>
         </div>

--- a/src/globals.css
+++ b/src/globals.css
@@ -37,6 +37,10 @@
   --color-border-strong: #0F0F0F;    /* 레트로 굵은 흑선용 */
   --color-border-focus: #DC2127;
 
+  /* Accent — 트렌디 그라데이션 파일럿(로그인)용 민트 팝. 레퍼런스의 형광 그린 스티커 톤. */
+  --color-accent-mint: #34E0A1;
+  --color-accent-mint-ink: #063D2B;  /* 민트 위 텍스트 (충분한 대비) */
+
   /* Shadows — chunky offset (옵션) + 일반 소프트 */
   --shadow-xs: 0 1px 2px rgba(15,15,15,0.06);
   --shadow-sm: 0 2px 4px rgba(15,15,15,0.08);
@@ -44,8 +48,8 @@
   --shadow-lg: 4px 4px 0 rgba(15,15,15,0.9);                /* 레트로 강조용 */
   --shadow-focus: 0 0 0 3px rgba(220,33,39,0.2);
 
-  /* Typography — 포스터의 굵은 지오메트릭 + Pretendard 한글 */
-  --font-display: 'Archivo Black', 'Archivo', 'Pretendard Variable', sans-serif;
+  /* Typography — 트렌디 라운드 헤비 그로테스크(Clash Display), 한글은 Pretendard, 폴백 Archivo */
+  --font-display: 'Clash Display', 'Archivo Black', 'Pretendard Variable', sans-serif;
   --font-body: 'Inter', 'Pretendard Variable', -apple-system, sans-serif;
   --font-sans: 'Inter', 'Pretendard Variable', -apple-system, sans-serif;
 }
@@ -263,6 +267,35 @@
   border: 2px solid var(--color-border-strong);
   background: var(--color-bg-surface);
   box-shadow: 3px 3px 0 rgba(15, 15, 15, 0.9);
+}
+
+/* === 트렌디 그라데이션 정체성 — 전역 적용 ===
+   레퍼런스(iDEAL→Wero)의 웜 그라데이션 + 둥근 헤비 그로테스크.
+   로그인 파일럿에서 검증 후 전체 페이지로 확장. */
+
+/* font-display 유틸은 font-family만 설정 → Clash Display가 400(light) 로 렌더링되는
+   문제 방지. base 레이어에서 weight를 700로 고정. */
+@layer base {
+  .font-display {
+    font-weight: 700;
+  }
+}
+
+/* 핫핑크 → 코랄 → 웜 옐로우 대각 그라데이션 (페이지 배경) */
+.bg-warm-gradient {
+  background: linear-gradient(135deg, #FF5E8A 0%, #FF8A5C 46%, #FBE36A 100%);
+}
+
+/* 퍼플 → 마젠타 → 핑크 비비드 그라데이션 (장식 블롭/악센트) */
+.bg-vivid-gradient {
+  background: linear-gradient(150deg, #8B3DF0 0%, #C13DE8 50%, #FF5EA8 100%);
+}
+
+/* 둥근 헤비 그로테스크 — Clash Display 전역, 한글은 Pretendard Variable 폴백 */
+.font-display-round {
+  font-family: 'Clash Display', 'Pretendard Variable', 'Archivo Black', sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## 작업 내용
레퍼런스(iDEAL→Wero)의 **웜 그라데이션 + 라운드 헤비 그로테스크 + 민트 팝 + 알약 버튼**을 기존 레트로 정체성(굵은 흑선·chunky 오프셋 그림자)과 **융합**해 전 페이지에 적용.

### 전역
- `--font-display` → Clash Display(Fontshare CDN), `font-display` base weight 700 고정
- 신규 유틸: `.bg-warm-gradient`, `.bg-vivid-gradient`, `.font-display-round`, 토큰 `accent-mint`
- `AgentOrb` `bold` 옵션(굵은 선 + 잉크 아웃라인)

### 페이지별
- **로그인/회원가입**: 그라데이션 셸 + bold orb(흰 원형 받침) + 민트 스티커 + 알약 brand 버튼
- **설정/공유/캘린더연동**: 그라데이션 셸 + 카드 `card-poster-static` 통일 + 인풋 강화 + 라운드 헤딩 + 알약 CTA
- **메인 챗 웰컴 히어로**: bold orb + 민트 스티커/블롭
- **챗 본문**: 가독성 위해 텍스트 뒤 그라데이션 미적용(유지)

### 품질
- code-reviewer 2패스 → HIGH 2건(폰트 de-weight, 그라데이션 위 텍스트 대비) 수정 완료. tsc/build/lint 통과, 그라데이션 위 텍스트 AA 확보, reduced-motion 처리.

## ⏪ 되돌리기 (팀 피드백 후 초기 복귀)
- 태그 `pre-trendy-redesign` (커밋 `f6adc84`)가 **리디자인 직전 상태**를 가리킴.
- 전체 되돌리려면: 이 PR 머지 커밋을 `Revert` 하거나, `git reset --hard pre-trendy-redesign` 후 배포.
- 폰트만 원복: `globals.css`의 `--font-display` 한 줄.

## 체크리스트
- [x] tsc + build 통과
- [x] lint 통과
- [x] 별도 리뷰 패스 2회
- [x] 롤백 태그 원격 푸시