### PR TITLE
feat: 메인 챗앱 크롬 트렌디 정체성 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,7 +39,7 @@ function NavButtons({
     <div className="relative flex items-center gap-0.5">
       <span
         aria-hidden
-        className="pointer-events-none absolute top-0 left-0 w-9 h-9 rounded-xl bg-brand-subtle transition-[transform,opacity] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+        className="pointer-events-none absolute top-0 left-0 w-9 h-9 rounded-xl bg-accent-mint border border-border-strong transition-[transform,opacity] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
         style={{
           transform: `translateX(${Math.max(activeIndex, 0) * 38}px)`,
           opacity: activeIndex >= 0 ? 1 : 0,
@@ -57,8 +57,8 @@ function NavButtons({
             className={cn(
               'relative z-10 w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200 cursor-pointer active:scale-[0.92] motion-safe:transition-transform',
               isActive
-                ? 'text-brand'
-                : 'text-text-muted hover:text-text-secondary hover:bg-bg-subtle',
+                ? 'text-accent-mint-ink'
+                : 'text-text-primary hover:bg-black/10',
             )}
             aria-label={item.label}
             aria-pressed={isActive}
@@ -68,7 +68,7 @@ function NavButtons({
               <span
                 className={cn(
                   'absolute -top-0.5 -right-0.5 min-w-[16px] h-[16px] px-1 rounded-full flex items-center justify-center text-[9.5px] font-semibold tabular-nums transition-colors',
-                  isActive ? 'bg-brand text-white' : 'bg-text-primary text-bg-surface',
+                  isActive ? 'bg-border-strong text-bg-surface' : 'bg-text-primary text-bg-surface',
                 )}
               >
                 {badge > 99 ? '99+' : badge}
@@ -168,12 +168,12 @@ export default function App() {
   return (
     <ErrorBoundary>
       <div className="h-full flex flex-col bg-bg-base">
-        <header className="flex items-center justify-between px-3 h-[52px] shrink-0 border-b border-border bg-bg-surface/90 backdrop-blur-md z-20">
+        <header className="flex items-center justify-between px-3 h-[52px] shrink-0 border-b-2 border-border-strong bg-warm-gradient z-20">
           <ChatHeader onOpenSidebar={openSidebar} onGoHome={goHome} />
           <div className="flex items-center gap-1">
             <button
               onClick={startTour}
-              className="w-9 h-9 rounded-xl flex items-center justify-center text-text-muted hover:text-text-secondary hover:bg-bg-subtle transition-colors cursor-pointer"
+              className="w-9 h-9 rounded-xl flex items-center justify-center text-text-primary hover:bg-black/10 transition-colors cursor-pointer"
               aria-label="기능 안내 다시 보기"
             >
               <HelpCircle size={17} strokeWidth={1.6} />
@@ -196,20 +196,20 @@ export default function App() {
                 : 'overlayIn 0.25s cubic-bezier(0.32, 0.72, 0, 1)',
             }}
           >
-            <header className="flex items-center justify-between px-3 h-[52px] shrink-0 border-b border-border bg-bg-surface">
+            <header className="flex items-center justify-between px-3 h-[52px] shrink-0 border-b-2 border-border-strong bg-warm-gradient">
               <button
                 onClick={closeOverlay}
                 className="flex items-center gap-2 cursor-pointer group"
                 aria-label="대화로 돌아가기"
               >
                 <div className="w-8 h-8 shrink-0">
-                  <AgentOrb state="idle" size={32} interactive={false} />
+                  <AgentOrb state="idle" size={32} interactive={false} bold />
                 </div>
                 <h2 className="text-[15px] font-semibold text-text-primary">
                   {NAV_ITEMS.find((n) => n.key === overlay)?.label}
                 </h2>
               </button>
-              <button onClick={closeOverlay} className="text-[13px] font-medium text-brand cursor-pointer px-2">닫기</button>
+              <button onClick={closeOverlay} className="text-[13px] font-semibold text-text-primary cursor-pointer px-2">닫기</button>
             </header>
             <div className="flex-1 overflow-hidden">
               <ErrorBoundary>

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -16,7 +16,7 @@ export default memo(function ChatHeader({ onOpenSidebar, onGoHome }: Props) {
       <button
         data-tour="sidebar"
         onClick={onOpenSidebar}
-        className="w-9 h-9 rounded-xl flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors cursor-pointer"
+        className="w-9 h-9 rounded-xl flex items-center justify-center text-text-primary hover:bg-black/10 transition-colors cursor-pointer"
         aria-label="대화 내역"
       >
         <Menu size={18} strokeWidth={1.8} />

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -212,29 +212,25 @@ export default memo(function ChatInput({ onSend, disabled, showChips, loading, o
             <button
               type="button"
               onClick={handleStop}
-              className="w-8 h-8 rounded-[10px] flex items-center justify-center bg-bg-subtle text-text-primary hover:bg-border transition-all duration-200 cursor-pointer shrink-0 active:scale-95"
+              className="w-8 h-8 rounded-full flex items-center justify-center border-2 border-border-strong bg-brand text-white shadow-[2px_2px_0_rgba(15,15,15,0.9)] transition-[transform,box-shadow] duration-150 cursor-pointer shrink-0 motion-safe:hover:-translate-x-px motion-safe:hover:-translate-y-px hover:shadow-[3px_3px_0_rgba(15,15,15,0.9)] motion-safe:active:translate-x-px motion-safe:active:translate-y-px active:shadow-[1px_1px_0_rgba(15,15,15,0.9)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-strong focus-visible:ring-offset-1"
               aria-label={uploading ? '사진 업로드 취소' : '응답 생성 중단'}
               title="중단"
             >
-              <Square size={12} fill="currentColor" strokeWidth={0} />
+              <Square size={11} fill="currentColor" strokeWidth={0} />
             </button>
           ) : (
             <button
               type="submit"
               disabled={!canSend}
               className={cn(
-                'w-8 h-8 rounded-[10px] flex items-center justify-center transition-all duration-200 cursor-pointer shrink-0',
+                'w-8 h-8 rounded-full flex items-center justify-center border-2 border-border-strong transition-[transform,box-shadow] duration-150 cursor-pointer shrink-0',
                 canSend
-                  ? 'bg-brand text-white shadow-xs hover:bg-brand-hover active:scale-95'
-                  : 'bg-bg-subtle text-text-muted',
+                  ? 'bg-brand text-white shadow-[2px_2px_0_rgba(15,15,15,0.9)] motion-safe:hover:-translate-x-px motion-safe:hover:-translate-y-px hover:shadow-[3px_3px_0_rgba(15,15,15,0.9)] motion-safe:active:translate-x-px motion-safe:active:translate-y-px active:shadow-[1px_1px_0_rgba(15,15,15,0.9)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-strong focus-visible:ring-offset-1'
+                  : 'bg-bg-subtle text-text-muted border-border opacity-50 cursor-not-allowed shadow-none',
               )}
-              aria-label={uploading ? '업로드 중' : '전송'}
+              aria-label="전송"
             >
-              {uploading ? (
-                <div className="w-3.5 h-3.5 border-2 border-white/60 border-t-white rounded-full animate-spin" />
-              ) : (
-                <ArrowUp size={15} strokeWidth={2.5} />
-              )}
+              <ArrowUp size={15} strokeWidth={2.5} />
             </button>
           )}
         </div>

--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -100,11 +100,11 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
         ref={sidebarRef}
         className="fixed left-0 top-0 bottom-0 z-50 w-[300px] bg-bg-surface border-r border-border flex flex-col will-change-transform"
       >
-        <div className="flex items-center justify-between px-4 h-[52px] border-b border-border shrink-0">
-          <h2 className="text-[14px] font-semibold text-text-primary">대화 내역</h2>
+        <div className="flex items-center justify-between px-4 h-[52px] border-b-2 border-border-strong bg-warm-gradient shrink-0">
+          <h2 className="font-display-round text-[15px] text-text-primary">대화 내역</h2>
           <button
             onClick={onClose}
-            className="w-7 h-7 rounded-lg flex items-center justify-center text-text-muted hover:text-text-primary hover:bg-bg-subtle transition-colors cursor-pointer"
+            className="w-7 h-7 rounded-lg flex items-center justify-center text-text-primary hover:bg-black/10 transition-colors cursor-pointer"
             aria-label="닫기"
           >
             <X size={15} />
@@ -114,7 +114,7 @@ export default memo(function ChatSidebar({ isOpen, onClose }: ChatSidebarProps) 
         <div className="px-3 pt-3 pb-1">
           <button
             onClick={handleNewChat}
-            className="w-full flex items-center gap-2 px-3 py-2.5 rounded-xl border border-border text-[13px] font-medium text-text-primary hover:bg-bg-subtle hover:border-border-strong transition-all cursor-pointer"
+            className="w-full flex items-center gap-2 px-4 py-2.5 rounded-full border-2 border-border-strong bg-brand text-white text-[13px] font-semibold shadow-[2px_2px_0_rgba(15,15,15,0.9)] transition-[transform,box-shadow] duration-150 cursor-pointer motion-safe:hover:-translate-x-px motion-safe:hover:-translate-y-px hover:shadow-[3px_3px_0_rgba(15,15,15,0.9)] motion-safe:active:translate-x-px motion-safe:active:translate-y-px active:shadow-[1px_1px_0_rgba(15,15,15,0.9)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-strong focus-visible:ring-offset-1"
           >
             <Plus size={14} />
             새 대화


### PR DESCRIPTION
## 작업 내용
로그인만 바뀌고 메인 화면(로그인 후 챗앱)은 그대로라는 피드백 반영 — 메인 셸 **크롬**에 정체성 적용. 챗 메시지 본문은 가독성 위해 calm 유지.

- 상단 헤더바 + 오버레이 패널 헤더: `bg-warm-gradient` + `border-b-2 border-border-strong` (모든 화면 상단이 바뀐 느낌의 핵심)
- 하단 네비 활성칩: `accent-mint`
- 입력창 전송/중단 버튼: brand 알약 + chunky 그림자 + motion-safe 프레스 + focus 링
- 사이드바 헤더 그라데이션 + 새 대화 알약 + 라운드 헤딩
- 그라데이션 위 텍스트/아이콘 `text-primary`로 AA 확보

## 품질
- code-reviewer 패스 → **SHIP**. uploading 스피너 제거 회귀 의심 → 스톱 버튼이 업로드 상태 커버 + 프리뷰 스피너 유지로 안전 확인. 스톱 버튼 focus 링 보완. 메시지 본문/MessageBubble/지도 미변경 확인.
- tsc/build/lint 통과

## ⏪ 되돌리기
리디자인 직전 태그 `pre-trendy-redesign`(f6adc84) 유효. 전체 복귀 시 이 PR + #119 함께 revert 또는 태그로 reset.

## 체크리스트
- [x] build/lint 통과
- [x] 별도 리뷰 패스
- [x] 메시지 가독성 영역 미변경