### PR TITLE
feat: 메인 챗앱 배경 웜 그라데이션 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,7 +167,7 @@ export default function App() {
 
   return (
     <ErrorBoundary>
-      <div className="h-full flex flex-col bg-bg-base">
+      <div className="h-full flex flex-col bg-warm-gradient">
         <header className="flex items-center justify-between px-3 h-[52px] shrink-0 border-b-2 border-border-strong bg-warm-gradient z-20">
           <ChatHeader onOpenSidebar={openSidebar} onGoHome={goHome} />
           <div className="flex items-center gap-1">

--- a/src/components/chat/ChatMessages.tsx
+++ b/src/components/chat/ChatMessages.tsx
@@ -105,17 +105,26 @@ export default memo(function ChatMessages() {
           >
             서울을<br />탐색해보세요
           </h2>
-          <p className="text-[14px] text-text-secondary text-center leading-[1.55] max-w-[280px]" style={{ wordBreak: 'keep-all' }}>
+          <p className="text-[14px] text-text-primary/75 text-center leading-[1.55] max-w-[280px]" style={{ wordBreak: 'keep-all' }}>
             장소 추천, 코스 설계, 예약까지<br />무엇이든 물어보세요
           </p>
         </div>
       )}
 
-      <div className="px-4 pb-4 space-y-5">
-        {messages.map((msg) => (
-          <MessageBubble key={msg.id} message={msg} />
-        ))}
-        <StreamingMessage />
+      {/* 메시지는 그라데이션 위 흰 시트에 담아 가독성 유지(레퍼런스: 컬러 배경 + 콘텐츠 시트) */}
+      <div className="px-3 pb-4">
+        <div
+          className={
+            messages.length > 0
+              ? 'mx-auto max-w-3xl bg-bg-surface/85 backdrop-blur-md rounded-2xl border-2 border-border-strong shadow-[3px_3px_0_rgba(15,15,15,0.9)] px-4 py-4 space-y-5'
+              : 'mx-auto max-w-3xl space-y-5'
+          }
+        >
+          {messages.map((msg) => (
+            <MessageBubble key={msg.id} message={msg} />
+          ))}
+          <StreamingMessage />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 작업 내용
"메인 화면도 바뀌어야지" 피드백 반영 — 메인 챗앱 **배경 자체**에 웜 그라데이션 적용.

- App 루트 `bg-bg-base` → `bg-warm-gradient` → 홈/웰컴/입력영역까지 컬러풀
- 메시지는 **반투명 흰 시트**(`bg-surface/85` + backdrop-blur + 굵은 흑선 + chunky 그림자)에 담아 가독성 유지 (레퍼런스의 '컬러 배경 + 콘텐츠 시트' 패턴)
- 웰컴 서브텍스트 `text-primary/75`로 대비 보정

## 가독성
어시스턴트 답변이 그라데이션 위 생텍스트로 깨지지 않도록, 메시지가 있을 때만 흰 시트로 감싸 텍스트는 흰 배경 위에 유지.

## ⏪ 되돌리기
태그 `pre-trendy-redesign`(f6adc84) 유효. 전체 복귀 시 #119/#120/이 PR revert 또는 태그 reset.

## 체크리스트
- [x] build/lint 통과
- [x] 메시지 가독성 시트 처리