### PR TITLE
feat: 지도/일정/북마크 패널 본문 트렌디 정체성 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -189,7 +189,7 @@ export default function App() {
 
         {overlay && (
           <div
-            className="fixed inset-0 z-30 bg-bg-base flex flex-col"
+            className="fixed inset-0 z-30 bg-warm-gradient flex flex-col"
             style={{
               animation: overlayClosing
                 ? 'overlayOut 0.2s cubic-bezier(0.32, 0.72, 0, 1) forwards'

--- a/src/components/bookmark/BookmarkPanel.tsx
+++ b/src/components/bookmark/BookmarkPanel.tsx
@@ -42,18 +42,18 @@ export default function BookmarkPanel({ onClose }: Props) {
   const counts = { place: places.length, message: messageItems.length };
 
   return (
-    <div className="h-full flex flex-col bg-bg-base">
+    <div className="h-full flex flex-col">
       {/* Segmented tabs — 슬라이딩 pill 인디케이터 */}
       <div className="px-4 pt-4 pb-3 shrink-0">
         <div
           role="tablist"
           aria-label="북마크 종류"
-          className="relative flex items-center gap-1 p-1 bg-bg-subtle rounded-full border border-border/60"
+          className="relative flex items-center gap-1 p-1 bg-bg-surface rounded-full border-2 border-border-strong shadow-[2px_2px_0_rgba(15,15,15,0.9)]"
         >
           {/* sliding pill — 활성 탭 인덱스(0/1)에 따라 50% 슬라이드 */}
           <span
             aria-hidden
-            className="pointer-events-none absolute top-1 bottom-1 left-1 w-[calc(50%-0.25rem)] rounded-full bg-bg-surface shadow-sm border border-border transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+            className="pointer-events-none absolute top-1 bottom-1 left-1 w-[calc(50%-0.25rem)] rounded-full bg-accent-mint border border-border-strong shadow-[1px_1px_0_rgba(15,15,15,0.9)] transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
             style={{
               transform: tab === 'message' ? 'translateX(calc(100% + 0.25rem))' : 'translateX(0)',
             }}
@@ -99,7 +99,7 @@ function TabButton({
       onClick={onClick}
       className={cn(
         'relative z-10 flex-1 flex items-center justify-center gap-1.5 h-9 rounded-full text-[13px] font-medium transition-colors duration-200 cursor-pointer active:scale-[0.97] motion-safe:transition-transform',
-        active ? 'text-text-primary' : 'text-text-muted hover:text-text-secondary',
+        active ? 'text-accent-mint-ink font-semibold' : 'text-text-primary hover:text-text-secondary',
       )}
     >
       {icon}
@@ -108,8 +108,8 @@ function TabButton({
         className={cn(
           'inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5 rounded-full text-[10px] font-semibold tabular-nums transition-colors',
           active
-            ? 'bg-brand-subtle text-brand'
-            : 'bg-bg-surface/80 text-text-muted',
+            ? 'bg-border-strong text-bg-surface'
+            : 'bg-bg-surface text-text-primary',
         )}
       >
         {count}
@@ -126,12 +126,14 @@ function PlaceBookmarks({ places, onClose }: { places: Place[]; onClose?: () => 
 
   if (places.length === 0) {
     return (
-      <EmptyState
-        lottieSrc="/animations/empty-place.json"
-        icon={<MapPin size={24} strokeWidth={1.2} />}
-        title="저장한 장소가 없어요"
-        description="채팅이나 지도에서 마음에 드는 장소를 저장해보세요"
-      />
+      <div className="card-poster-static rounded-2xl p-8 mx-4 mt-4 text-center">
+        <EmptyState
+          lottieSrc="/animations/empty-place.json"
+          icon={<MapPin size={24} strokeWidth={1.2} />}
+          title="저장한 장소가 없어요"
+          description="채팅이나 지도에서 마음에 드는 장소를 저장해보세요"
+        />
+      </div>
     );
   }
 
@@ -142,7 +144,7 @@ function PlaceBookmarks({ places, onClose }: { places: Place[]; onClose?: () => 
         return (
           <article
             key={place.id}
-            className="group flex items-center gap-3 p-2 bg-bg-surface border border-border rounded-2xl transition-all duration-200 hover:border-border-strong hover:shadow-sm cursor-pointer"
+            className="group flex items-center gap-3 p-2 card-poster-static rounded-2xl transition-[box-shadow,transform] duration-150 hover:shadow-[4px_4px_0_rgba(15,15,15,0.9)] motion-safe:hover:-translate-x-0.5 motion-safe:hover:-translate-y-0.5 cursor-pointer"
             onClick={() => { selectPlace(place); }}
           >
             <div
@@ -215,7 +217,7 @@ function MessageBookmarks({ items, onClose }: { items: MessageBookmarkItem[]; on
       return (
         <div className="px-4 pt-2 space-y-2.5">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="bg-bg-surface border border-border rounded-2xl p-3.5 space-y-2">
+            <div key={i} className="card-poster-static rounded-2xl p-3.5 space-y-2">
               <div className="flex items-center gap-2">
                 <div className="w-[18px] h-[18px] rounded-md bg-bg-subtle animate-pulse" />
                 <div className="h-3 w-16 rounded bg-bg-subtle animate-pulse" />
@@ -230,10 +232,10 @@ function MessageBookmarks({ items, onClose }: { items: MessageBookmarkItem[]; on
     if (error) {
       return (
         <div className="flex flex-col items-center justify-center py-12 text-center px-4">
-          <p className="text-[13px] text-text-secondary mb-3">{error}</p>
+          <p className="text-[13px] text-text-primary mb-3">{error}</p>
           <button
             onClick={() => loadFromServer()}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-[12px] text-text-primary hover:bg-bg-subtle transition-colors cursor-pointer"
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full border-2 border-border-strong bg-bg-surface text-[12px] font-semibold text-text-primary shadow-[2px_2px_0_rgba(15,15,15,0.9)] hover:shadow-[3px_3px_0_rgba(15,15,15,0.9)] transition-[box-shadow] cursor-pointer"
           >
             다시 시도
           </button>
@@ -241,12 +243,14 @@ function MessageBookmarks({ items, onClose }: { items: MessageBookmarkItem[]; on
       );
     }
     return (
-      <EmptyState
-        lottieSrc="/animations/empty-message.json"
-        icon={<Sparkles size={24} strokeWidth={1.2} />}
-        title="저장한 대화가 없어요"
-        description="에이전트 답변 위에 마우스를 올리면 북마크 아이콘이 나타나요"
-      />
+      <div className="card-poster-static rounded-2xl p-8 mx-4 mt-4 text-center">
+        <EmptyState
+          lottieSrc="/animations/empty-message.json"
+          icon={<Sparkles size={24} strokeWidth={1.2} />}
+          title="저장한 대화가 없어요"
+          description="에이전트 답변 위에 마우스를 올리면 북마크 아이콘이 나타나요"
+        />
+      </div>
     );
   }
 
@@ -260,7 +264,7 @@ function MessageBookmarks({ items, onClose }: { items: MessageBookmarkItem[]; on
         return (
           <article
             key={item.bookmarkId}
-            className="group relative bg-bg-surface border border-border rounded-2xl p-3.5 transition-all duration-200 hover:border-border-strong hover:shadow-sm cursor-pointer"
+            className="group relative card-poster-static rounded-2xl p-3.5 transition-[box-shadow,transform] duration-150 hover:shadow-[4px_4px_0_rgba(15,15,15,0.9)] motion-safe:hover:-translate-x-0.5 motion-safe:hover:-translate-y-0.5 cursor-pointer"
             onClick={() => { loadSession(item.conversationId, { focusMessageId: item.messageId }); onClose?.(); }}
           >
             <div className="flex items-center gap-2 mb-2">
@@ -352,10 +356,7 @@ function EmptyState({
           {icon}
         </div>
       )}
-      <h3
-        className="text-[20px] text-text-primary mb-2 tracking-[-0.02em]"
-        style={{ fontFamily: 'var(--font-display)' }}
-      >
+      <h3 className="font-display-round text-[20px] text-text-primary mb-2">
         {title}
       </h3>
       <p className="text-[13px] text-text-muted max-w-[240px] mx-auto leading-[1.65]">

--- a/src/components/calendar/CalendarPanel.tsx
+++ b/src/components/calendar/CalendarPanel.tsx
@@ -26,7 +26,7 @@ function GoogleCalendarConnectBar() {
       <button
         onClick={onConnect}
         disabled={busy}
-        className="w-full flex items-center justify-center gap-1.5 py-2.5 rounded-xl border border-border bg-bg-surface hover:border-border-strong hover:bg-bg-subtle transition-colors text-[12px] font-medium text-text-primary disabled:opacity-60 cursor-pointer"
+        className="w-full flex items-center justify-center gap-1.5 py-2.5 rounded-full border-2 border-border-strong bg-bg-surface shadow-[2px_2px_0_rgba(15,15,15,0.9)] hover:shadow-[3px_3px_0_rgba(15,15,15,0.9)] transition-[box-shadow] text-[12px] font-semibold text-text-primary disabled:opacity-60 cursor-pointer"
       >
         <Link2 size={13} />
         {busy ? '이동 중...' : 'Google Calendar 연동'}
@@ -39,13 +39,15 @@ function NotConnectedPanel() {
   return (
     <div className="h-full flex flex-col">
       <GoogleCalendarConnectBar />
-      <div className="flex-1 flex items-center justify-center">
-        <EmptyState
-          icon={Link2}
-          title="Google Calendar 연동 필요"
-          description="연동하면 에이전트가 만든 일정이 여기에 표시됩니다"
-          lottieSrc="/animations/calender.json"
-        />
+      <div className="flex-1 flex items-center justify-center p-4">
+        <div className="card-poster-static rounded-2xl p-8 w-full text-center">
+          <EmptyState
+            icon={Link2}
+            title="Google Calendar 연동 필요"
+            description="연동하면 에이전트가 만든 일정이 여기에 표시됩니다"
+            lottieSrc="/animations/calender.json"
+          />
+        </div>
       </div>
     </div>
   );
@@ -69,7 +71,7 @@ function EventCard({ event }: { event: CalendarEventItem }) {
   const isLocalBiz = event.source === 'localbiz';
 
   return (
-    <div className="bg-bg-surface border border-border rounded-2xl overflow-hidden">
+    <div className="card-poster-static rounded-2xl overflow-hidden">
       <div className="px-4 py-3 border-b border-border bg-bg-subtle/50">
         <div className="flex items-center justify-between gap-2 mb-1">
           <h3 className="text-[14px] font-semibold text-text-primary tracking-[-0.02em] flex-1 truncate">
@@ -137,11 +139,13 @@ export default function CalendarPanel() {
   if (!authToken) {
     return (
       <div className="h-full flex items-center justify-center">
-        <EmptyState
-          icon={Calendar}
-          title="로그인 필요"
-          description="로그인하면 일정이 여기에 표시됩니다"
-        />
+        <div className="card-poster-static rounded-2xl p-8 mx-4 text-center">
+          <EmptyState
+            icon={Calendar}
+            title="로그인 필요"
+            description="로그인하면 일정이 여기에 표시됩니다"
+          />
+        </div>
       </div>
     );
   }
@@ -153,7 +157,7 @@ export default function CalendarPanel() {
   if (loading && events.length === 0) {
     return (
       <div className="h-full flex items-center justify-center">
-        <div className="w-5 h-5 border-2 border-brand/30 border-t-brand rounded-full animate-spin" />
+        <div className="w-5 h-5 border-2 border-border-strong rounded-full animate-spin border-t-brand" />
       </div>
     );
   }
@@ -163,12 +167,12 @@ export default function CalendarPanel() {
       <div className="h-full flex flex-col">
         <GoogleCalendarConnectBar />
         <div className="flex-1 flex items-center justify-center px-6">
-          <div className="text-center">
-            <AlertCircle size={28} className="mx-auto mb-2 text-[#DC2626]" />
-            <p className="text-[13px] text-text-secondary mb-3">{error}</p>
+          <div className="card-poster-static rounded-2xl p-6 text-center w-full max-w-xs">
+            <AlertCircle size={28} className="mx-auto mb-2 text-brand" />
+            <p className="text-[13px] text-text-primary mb-3">{error}</p>
             <button
               onClick={loadFromServer}
-              className="px-3 py-1.5 rounded-lg border border-border text-[12px] text-text-primary hover:bg-bg-subtle cursor-pointer"
+              className="px-4 py-1.5 rounded-full border-2 border-border-strong text-[12px] font-semibold text-text-primary shadow-[2px_2px_0_rgba(15,15,15,0.9)] hover:shadow-[3px_3px_0_rgba(15,15,15,0.9)] transition-[box-shadow] cursor-pointer"
             >
               다시 시도
             </button>
@@ -182,13 +186,15 @@ export default function CalendarPanel() {
     return (
       <div className="h-full flex flex-col">
         <GoogleCalendarConnectBar />
-        <div className="flex-1 flex items-center justify-center">
-          <EmptyState
-            icon={Calendar}
-            title="일정 없음"
-            description="에이전트에게 일정을 만들어달라고 해보세요"
-            lottieSrc="/animations/calender.json"
-          />
+        <div className="flex-1 flex items-center justify-center p-4">
+          <div className="card-poster-static rounded-2xl p-8 w-full text-center">
+            <EmptyState
+              icon={Calendar}
+              title="일정 없음"
+              description="에이전트에게 일정을 만들어달라고 해보세요"
+              lottieSrc="/animations/calender.json"
+            />
+          </div>
         </div>
       </div>
     );

--- a/src/components/map/MapPanel.tsx
+++ b/src/components/map/MapPanel.tsx
@@ -110,10 +110,10 @@ export default function MapPanel() {
   useEffect(() => { if (is3D) setHeatmapOn(false); }, [is3D]);
 
   return (
-    <div className="h-full flex flex-col md:flex-row bg-bg-base">
+    <div className="h-full flex flex-col md:flex-row bg-warm-gradient">
       {/* Map area */}
       <div className="flex-1 flex flex-col min-h-0">
-        <div className="flex-1 relative m-3 overflow-hidden rounded-2xl border border-border shadow-sm">
+        <div className="flex-1 relative m-3 overflow-hidden rounded-2xl border-2 border-border-strong shadow-[3px_3px_0_rgba(15,15,15,0.9)]">
           {hasContent ? (
             <>
               {is3D ? (


### PR DESCRIPTION
## 작업 내용
"지도랑 일정도 적용한거 맞아?" 피드백 반영 — 헤더만 적용됐던 오버레이 패널 **본문**까지 적용.

- 오버레이 컨테이너 + MapPanel 루트 → `bg-warm-gradient` (지도 카드 프레임 `border-2 border-border-strong` + chunky 그림자로 포스터화)
- 일정/북마크 카드 → `card-poster-static`, 북마크 탭 활성칩 민트
- 빈/로딩/에러 상태 4곳을 surface 카드로 감싸 그라데이션 위 텍스트 가독성 확보
- 그라데이션 위 텍스트 `text-primary`, 헤딩 `font-display-round`

## 품질
code-reviewer 패스 → 빈 상태 가독성 HIGH 3건 지적 → surface 카드 래핑으로 수정 완료. tsc/build/lint 통과. 지도 타일은 위젯이라 미적용(프레임/여백만), 챗 메시지/블록 카드 미변경 확인.

## ⏪ 되돌리기
태그 `pre-trendy-redesign`(f6adc84) 유효.

## 체크리스트
- [x] build/lint 통과
- [x] 리뷰 패스 + 가독성 수정