### PR TITLE
fix: 장소 북마크 삭제 버튼도 항상 표시

### DIFF
--- a/src/components/bookmark/BookmarkPanel.tsx
+++ b/src/components/bookmark/BookmarkPanel.tsx
@@ -189,7 +189,7 @@ function PlaceBookmarks({ places, onClose }: { places: Place[]; onClose?: () => 
             </div>
             <button
               onClick={(e) => { e.stopPropagation(); removeBookmark(place.id); }}
-              className="opacity-0 group-hover:opacity-100 w-8 h-8 rounded-lg flex items-center justify-center text-text-muted hover:text-[#DC2626] hover:bg-[#FEF2F2] transition-all cursor-pointer shrink-0"
+              className="w-8 h-8 rounded-lg flex items-center justify-center text-text-muted hover:text-[#DC2626] hover:bg-[#FEF2F2] transition-colors cursor-pointer shrink-0"
               aria-label={`${place.name} 북마크 해제`}
             >
               <Trash2 size={14} />


### PR DESCRIPTION
## 작업 내용
장소 북마크 삭제 버튼의 hover 전용 표시(`opacity-0 group-hover:opacity-100`)를 제거해 **상시 노출**. 대화 북마크(#123)와 동일 처리로 일관성 확보.

## 체크리스트
- [x] build/lint 통과