### PR TITLE
fix: 북마크 탭 인디케이터 좌우 대칭 패딩

### DIFF
--- a/src/components/bookmark/BookmarkPanel.tsx
+++ b/src/components/bookmark/BookmarkPanel.tsx
@@ -53,7 +53,7 @@ export default function BookmarkPanel({ onClose }: Props) {
           {/* sliding pill — 활성 탭 인덱스(0/1)에 따라 50% 슬라이드 */}
           <span
             aria-hidden
-            className="pointer-events-none absolute top-1 bottom-1 left-1 w-[calc(50%-0.25rem)] rounded-full bg-accent-mint border border-border-strong shadow-[1px_1px_0_rgba(15,15,15,0.9)] transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
+            className="pointer-events-none absolute top-1 bottom-1 left-1 w-[calc(50%-0.375rem)] rounded-full bg-accent-mint border border-border-strong shadow-[1px_1px_0_rgba(15,15,15,0.9)] transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]"
             style={{
               transform: tab === 'message' ? 'translateX(calc(100% + 0.25rem))' : 'translateX(0)',
             }}


### PR DESCRIPTION
## 작업 내용
북마크 세그먼트 탭의 슬라이딩 pill이 **대화 탭 활성 시 오른쪽 끝에 닿던** 문제 수정. pill 너비를 `calc(50%-0.25rem)` → `calc(50%-0.375rem)`로 보정(`p-1`+`gap-1` 고려한 실제 버튼 너비)해 양쪽 0.25rem 대칭 패딩 + 버튼 정렬.

## 참고
삭제 버튼은 #123/#124에서 이미 상시 표시 처리됨(코드상 visibility 게이트 0개). 라이브에서 hover-only로 보이면 Vercel 배포 반영/캐시 지연.

## 체크리스트
- [x] build/lint 통과