### PR TITLE
fix: 비교 차트 등 블록 렌더 크래시 방어

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -9,6 +9,7 @@ import AgentMark from '../agent/AgentMark';
 import FeedbackButton from './FeedbackButton';
 import ShareButton from './ShareButton';
 import Markdown from '@/components/ui/Markdown';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 
 // 무거운 카드/블록(지도·코스·예약·블록 렌더러)은 lazy 분리 — 웰컴/단순 텍스트 메시지에는
 // 필요 없으므로 메인 번들에서 제외해 초기 로드(FCP/LCP)를 줄인다. 추천이 도착할 때 청크 fetch.
@@ -176,7 +177,12 @@ export default memo(function MessageBubble({ message }: { message: Message }) {
               <div data-reveal className="space-y-2">
                 <Suspense fallback={null}>
                   {message.blocks.map((block, i) => (
-                    <BlockRenderer key={`${block.type}-${i}`} block={block} places={message.places} />
+                    <ErrorBoundary
+                      key={`${block.type}-${i}`}
+                      fallback={<div className="text-[12px] text-text-muted px-1 py-0.5">이 항목을 표시할 수 없어요.</div>}
+                    >
+                      <BlockRenderer block={block} places={message.places} />
+                    </ErrorBoundary>
                   ))}
                 </Suspense>
               </div>

--- a/src/components/chat/blocks/ChartBlock.tsx
+++ b/src/components/chat/blocks/ChartBlock.tsx
@@ -21,6 +21,9 @@ export default function ChartBlock({ data }: { data: ChartBlockData }) {
   const cy = size / 2;
   const radius = 100;
   const angles = METRICS.map((_, i) => (i * 2 * Math.PI) / METRICS.length - Math.PI / 2);
+  // BE 가 datasets 없이 chart 블록을 보내면 .map 에서 크래시 → 방어 가드.
+  const datasets = data.datasets ?? [];
+  if (datasets.length === 0) return null;
 
   return (
     <div className="rounded-xl border border-border bg-bg-surface p-4">
@@ -55,7 +58,7 @@ export default function ChartBlock({ data }: { data: ChartBlockData }) {
           );
         })}
         {/* datasets */}
-        {data.datasets.map((ds, di) => {
+        {datasets.map((ds, di) => {
           const color = DATASET_COLORS[di % DATASET_COLORS.length];
           const points = METRICS.map((m, i) => {
             const v = (ds[m.key] ?? 0) as number;
@@ -76,7 +79,7 @@ export default function ChartBlock({ data }: { data: ChartBlockData }) {
         })}
       </svg>
       <div className="flex flex-wrap gap-x-4 gap-y-1.5 justify-center mt-3 text-xs">
-        {data.datasets.map((ds, di) => (
+        {datasets.map((ds, di) => (
           <div key={ds.label + di} className="flex items-center gap-1.5">
             <span
               className="inline-block w-3 h-3 rounded-sm"

--- a/src/components/chat/blocks/MapRouteBlock.tsx
+++ b/src/components/chat/blocks/MapRouteBlock.tsx
@@ -9,7 +9,7 @@ const MODE_LABEL: Record<string, string> = {
 };
 
 export default function MapRouteBlock({ data }: { data: MapRouteData }) {
-  const stopCount = data.markers.length;
+  const stopCount = data.markers?.length ?? 0;
   const segments = data.polyline?.segments ?? [];
   const uniqueModes = Array.from(new Set(segments.map((s) => s.mode)));
   const modeText = uniqueModes.length > 0


### PR DESCRIPTION
## 작업 내용
"비교" 요청 시 `Cannot read properties of undefined (reading 'map')` 크래시 수정.

- **ChartBlock**: `data.datasets`를 무방비로 `.map` → BE가 datasets 없이 chart 블록을 보내면 크래시(REVIEW_COMPARE 비교 응답). `?? []` 가드 + 빈 경우 null 반환.
- **BlockRenderer를 블록별 ErrorBoundary로 감싸기** — 앞으로 어떤 블록이 렌더 중 throw해도 채팅 전체가 죽지 않고 해당 항목만 '표시할 수 없어요'로 degrade.
- **MapRouteBlock**: `data.markers` 옵셔널 방어.

## 배경
BE 복구 후 비교 쿼리(REVIEW_COMPARE)에서 발생. 나머지 블록(References/AnalysisSources/Disambiguation)은 이미 가드되어 있었고 ChartBlock만 무방비였음.

## 체크리스트
- [x] build/lint 통과