### PR TITLE
fix: 비교 레이더 차트 BE places/scores 형식 정합

### DIFF
--- a/src/components/chat/blocks/ChartBlock.tsx
+++ b/src/components/chat/blocks/ChartBlock.tsx
@@ -21,9 +21,10 @@ export default function ChartBlock({ data }: { data: ChartBlockData }) {
   const cy = size / 2;
   const radius = 100;
   const angles = METRICS.map((_, i) => (i * 2 * Math.PI) / METRICS.length - Math.PI / 2);
-  // BE 가 datasets 없이 chart 블록을 보내면 .map 에서 크래시 → 방어 가드.
-  const datasets = data.datasets ?? [];
-  if (datasets.length === 0) return null;
+  // BE review_compare 가 보내는 places[] 를 source of truth 로 읽는다(scores: 6지표).
+  // 빈/누락이면 차트 생략(크래시 방지).
+  const places = data.places ?? [];
+  if (places.length === 0) return null;
 
   return (
     <div className="rounded-xl border border-border bg-bg-surface p-4">
@@ -58,17 +59,17 @@ export default function ChartBlock({ data }: { data: ChartBlockData }) {
           );
         })}
         {/* datasets */}
-        {datasets.map((ds, di) => {
+        {places.map((p, di) => {
           const color = DATASET_COLORS[di % DATASET_COLORS.length];
           const points = METRICS.map((m, i) => {
-            const v = (ds[m.key] ?? 0) as number;
+            const v = p.scores?.[m.key] ?? 0;
             const r = Math.max(0, Math.min(1, v / 5)) * radius;
             const a = angles[i];
             return `${cx + Math.cos(a) * r},${cy + Math.sin(a) * r}`;
           }).join(' ');
           return (
             <polygon
-              key={ds.label + di}
+              key={p.name + di}
               points={points}
               fill={color}
               fillOpacity={0.18}
@@ -79,16 +80,16 @@ export default function ChartBlock({ data }: { data: ChartBlockData }) {
         })}
       </svg>
       <div className="flex flex-wrap gap-x-4 gap-y-1.5 justify-center mt-3 text-xs">
-        {datasets.map((ds, di) => (
-          <div key={ds.label + di} className="flex items-center gap-1.5">
+        {places.map((p, di) => (
+          <div key={p.name + di} className="flex items-center gap-1.5">
             <span
               className="inline-block w-3 h-3 rounded-sm"
               style={{ background: DATASET_COLORS[di % DATASET_COLORS.length] }}
             />
-            <span className="text-text-primary">{ds.label}</span>
-            {ds.score_satisfaction != null && (
+            <span className="text-text-primary">{p.name}</span>
+            {p.scores?.satisfaction != null && (
               <span className="text-text-muted tabular-nums">
-                · 만족도 {ds.score_satisfaction.toFixed(1)}
+                · 만족도 {p.scores.satisfaction.toFixed(1)}
               </span>
             )}
           </div>

--- a/src/mocks/agent-responses.ts
+++ b/src/mocks/agent-responses.ts
@@ -64,9 +64,9 @@ export async function* streamResponse(
       {
         type: 'chart',
         chart_type: 'radar',
-        datasets: [
-          { label: '광장시장', score_satisfaction: 4.6, accessibility: 4.2, cleanliness: 3.5, value: 4.8, atmosphere: 4.7, expertise: 4.3 },
-          { label: '망원시장', score_satisfaction: 4.4, accessibility: 4.0, cleanliness: 3.8, value: 4.5, atmosphere: 4.5, expertise: 4.0 },
+        places: [
+          { name: '광장시장', scores: { satisfaction: 4.6, accessibility: 4.2, cleanliness: 3.5, value: 4.8, atmosphere: 4.7, expertise: 4.3 } },
+          { name: '망원시장', scores: { satisfaction: 4.4, accessibility: 4.0, cleanliness: 3.8, value: 4.5, atmosphere: 4.5, expertise: 4.0 } },
         ],
       },
       {

--- a/src/mocks/msw/handlers.ts
+++ b/src/mocks/msw/handlers.ts
@@ -554,9 +554,9 @@ function buildSseStream(query: string, threadId: string): ReadableStream<Uint8Ar
         send('chart', {
           type: 'chart',
           chart_type: 'radar',
-          datasets: [
-            { label: '광장시장', score_satisfaction: 4.6, accessibility: 4.2, cleanliness: 3.5, value: 4.8, atmosphere: 4.7, expertise: 4.3 },
-            { label: '망원시장', score_satisfaction: 4.4, accessibility: 4.0, cleanliness: 3.8, value: 4.5, atmosphere: 4.5, expertise: 4.0 },
+          places: [
+            { name: '광장시장', scores: { satisfaction: 4.6, accessibility: 4.2, cleanliness: 3.5, value: 4.8, atmosphere: 4.7, expertise: 4.3 } },
+            { name: '망원시장', scores: { satisfaction: 4.4, accessibility: 4.0, cleanliness: 3.8, value: 4.5, atmosphere: 4.5, expertise: 4.0 } },
           ],
         });
         await wait(80);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -324,20 +324,27 @@ export type MapRouteBlock = {
   polyline: MapRoutePolyline;
 };
 
-export type ChartDataset = {
-  label: string;
-  score_satisfaction?: number;
-  accessibility?: number;
-  cleanliness?: number;
-  value?: number;
-  atmosphere?: number;
-  expertise?: number;
+// BE review_compare_node 가 보내는 실제 형태: places[].scores{6지표}.
+// (불변식 #6 으로 key 고정 — satisfaction 포함 6개, 이름 변경 금지)
+export type ChartPlaceScores = {
+  satisfaction?: number;   // 종합 만족도 — 축 제외, 범례에 표기
+  accessibility?: number;  // 접근성
+  cleanliness?: number;    // 청결도
+  value?: number;          // 가성비
+  atmosphere?: number;     // 분위기
+  expertise?: number;      // 전문성
+};
+
+export type ChartPlace = {
+  name: string;
+  scores: ChartPlaceScores;
 };
 
 export type ChartBlock = {
   type: 'chart';
   chart_type: 'radar';
-  datasets: ChartDataset[];
+  title?: string;
+  places: ChartPlace[];
 };
 
 export type CalendarBlock = {


### PR DESCRIPTION
## 작업 내용
"비교" 응답의 오각형 레이더 차트가 안 그려지던 진짜 원인 수정.

**근본 원인**: BE `review_compare_node`는 `{type:'chart', chart_type:'radar', places:[{name, scores:{6지표}}]}` 로 **정상 전송 중**이었음(와이어 확인: '교촌치킨이랑 BBQ 비교' → chart 블록 정상 수신). FE `ChartBlock`이 잘못된 키 `data.datasets` 를 읽어 항상 미렌더였음.

- `ChartBlock.tsx` + `types/api.ts` 를 BE 스키마(`places/scores`, 불변식 #6: satisfaction 포함 6키)로 수정
- `satisfaction` 은 축 제외·범례 표기(기존 5축 디자인 유지)
- 기존 mock chart 샘플(agent-responses, msw handlers)도 새 형식으로 갱신
- 이전의 잘못된 BE 요청 문서(`datasets`/`score_satisfaction` 가정) 삭제

> 참고: '0개' 측정의 일부는 `disambiguation` 분기(장소 2개 해석 실패)였음 — BE 정상.

## 체크리스트
- [x] build/lint 통과